### PR TITLE
Feature/reduce memory allocations while reading

### DIFF
--- a/src/process.rs
+++ b/src/process.rs
@@ -117,6 +117,11 @@ pub fn process_tile(
                     }
                 }
                 i += 1;
+                // we only care about the third line, so break after that to avoid having to read
+                // the entire file line by line (file is large)
+                if i > 2 {
+                    break;
+                }
             }
         }
     }

--- a/src/util.rs
+++ b/src/util.rs
@@ -14,7 +14,7 @@ where
 
 /// Iterates over the lines in a file and calls the callback with a &str reference to each line.
 /// This function does not allocate new strings for each line, as opposed to using
-/// [`io::BufReader::lines()`].
+/// [`io::BufReader::lines()`] as in [`read_lines`].
 pub fn read_lines_no_alloc<P>(filename: P, mut line_callback: impl FnMut(&str)) -> io::Result<()>
 where
     P: AsRef<Path>,


### PR DESCRIPTION
Builds on #8 so need to merge that before raising this PR.

Went through and changed uses of `read_lines` with `read_lines_no_alloc` to remove more uneccessary memory allocations.

Profiling with dhat shows the following;

Before
```
    Total:     21,712,247,777 bytes (100%, 20,904.58/Minstr) in 107,002,100 blocks (100%, 103.02/Minstr), avg size 202.91 bytes, avg lifetime 658,535,753.86 instrs (0.06% of program duration)
    At t-gmax: 932,778,145 bytes (100%) in 669 blocks (100%), avg size 1,394,287.21 bytes
    At t-end:  0 bytes (0%) in 0 blocks (0%), avg size 0 bytes
    Reads:     357,483,736,862 bytes (100%, 344,185.76/Minstr), 16.46/byte
    Writes:    86,566,352,275 bytes (100%, 83,346.18/Minstr), 3.99/byte
```

After
```
    Total:     18,574,142,840 bytes (100%, 18,124.34/Minstr) in 30,129,336 blocks (100%, 29.4/Minstr), avg size 616.48 bytes, avg lifetime 2,262,840,132.74 instrs (0.22% of program duration)
    At t-gmax: 932,778,145 bytes (100%) in 669 blocks (100%), avg size 1,394,287.21 bytes
    At t-end:  0 bytes (0%) in 0 blocks (0%), avg size 0 bytes
    Reads:     356,800,834,392 bytes (100%, 348,160.35/Minstr), 19.21/byte
    Writes:    86,558,292,901 bytes (100%, 84,462.15/Minstr), 4.66/byte
```

The biggest change is in the number of allocated blocks (which is roughly chunks of memory / calls to `malloc`) that reduced from over 100,000,000 down to 30,000,000 (so a reduction to with 70%). The total number of allocated bytes only reduced by ~14%, which is expected since the allocations we now avoid are small short-lived allocations (eg. each line in the files), and there are still substantial allocations being made (but at a much lower frequency and in bigger chunks, hence the reduction in number of blocks) :fire: 
