### PR TITLE
add workflow for checking regression against main

### DIFF
--- a/.github/workflows/regression.yml
+++ b/.github/workflows/regression.yml
@@ -25,8 +25,10 @@ jobs:
       id: run_pr_branch
       run: |
         echo "Running code on PR branch"
+        compare -list resource
         cargo run --release -- test_file.laz
         mv pullautus.png pullautus_pr.png
+        mv pullautus_depr.png pullautus_depr_pr.png
         rm -rf temp/
 
     - name: Checkout main branch
@@ -40,6 +42,7 @@ jobs:
         echo "Running code on main branch"
         cargo run --release -- test_file.laz
         mv pullautus.png pullautus_main.png
+        mv pullautus_depr.png pullautus_depr_main.png
 
     - name: Compare results
       id: compare
@@ -47,7 +50,8 @@ jobs:
         # Compare the results from both branches
         # install imagemagic to do the comparison ( Seems to work and already be included with ubuntu-latest)
         sudo apt install imagemagick 
-        imagemagic compare -metric PSNR pullautus_main.png pullautus_pr.png difference.png
+        compare -metric PSNR pullautus_main.png pullautus_pr.png difference.png
+        compare -metric PSNR pullautus_depr_main.png pullautus_depr_pr.png difference_depr.png
     
     - name: Upload results
       uses: actions/upload-artifact@v4
@@ -57,5 +61,8 @@ jobs:
           pullautus_main.png
           pullautus_pr.png
           difference.png
+          pullautus_depr_main.png
+          pullautus_depr_pr.png
+          difference_depr.png
         overwrite: true # we need subsequent runs to overwrite the result
 

--- a/.github/workflows/regression.yml
+++ b/.github/workflows/regression.yml
@@ -31,7 +31,7 @@ jobs:
         mv pullautus_depr.png pullautus_depr_pr.png
         rm -rf temp/
 
-    - name: Checkout main branch
+    - name: Checkout master branch
       run: |
         git fetch origin master
         git checkout master
@@ -44,14 +44,15 @@ jobs:
         mv pullautus.png pullautus_main.png
         mv pullautus_depr.png pullautus_depr_main.png
 
-    - name: Compare results
+    - name: Compare results (pngcomp)
       id: compare
       run: |
         # Compare the results from both branches
-        # install imagemagic to do the comparison ( Seems to work and already be included with ubuntu-latest)
-        sudo apt install imagemagick 
-        compare -metric PSNR pullautus_main.png pullautus_pr.png difference.png
-        compare -metric PSNR pullautus_depr_main.png pullautus_depr_pr.png difference_depr.png
+        sudo apt install pngnq 
+        printf "\n\n##### Comparing without depressions:\n"
+        pngcomp pullautus_main.png pullautus_pr.png | tee pngcomp.txt
+        printf "\n\n##### Comparing with depressions:\n"
+        pngcomp pullautus_depr_main.png pullautus_depr_pr.png | tee pngcomp_depr.txt
     
     - name: Upload results
       uses: actions/upload-artifact@v4
@@ -60,9 +61,28 @@ jobs:
         path: |
           pullautus_main.png
           pullautus_pr.png
-          difference.png
+          pngcomp.txt
           pullautus_depr_main.png
           pullautus_depr_pr.png
-          difference_depr.png
+          pngcomp_depr.txt
         overwrite: true # we need subsequent runs to overwrite the result
+
+    - name: Check for differences
+      run: |
+        # Analyze metrics: if there is a change this step should fail!
+
+        # Here we could check any of the metrics output by pngcomp. for now we check the
+        # percentage of overlapping/correct pixels and fail the job if it is less than 100%
+        value=$(sed -rn 's/Percentage correct pixels: ([0-9]+\.[0-9]+)$/\1/p' pngcomp.txt)
+        value_depr=$(sed -rn 's/Percentage correct pixels: ([0-9]+\.[0-9]+)$/\1/p' pngcomp_depr.txt)
+
+        if (( $(echo "$value < 100.0" | bc -l) )); then
+          echo "Percentage of correct pixels (without depressions) is $value < 100%. Output has changed!";
+          exit 1
+        fi
+
+        if (( $(echo "$value_depr < 100.0" | bc -l) )); then
+          echo "Percentage of correct pixels (with depressions) is $value_depr < 100%. Output has changed!";
+          exit 1
+        fi
 

--- a/.github/workflows/regression.yml
+++ b/.github/workflows/regression.yml
@@ -27,13 +27,14 @@ jobs:
         echo "Running code on PR branch"
         cargo run --release -- test_file.laz
         mv pullautus.png pullautus_pr.png
+        rm -rf temp/
 
     - name: Checkout main branch
       run: |
-        git fetch origin main
-        git checkout main
+        git fetch origin master
+        git checkout master
 
-    - name: Run code on main branch
+    - name: Run code on master branch
       id: run_main_branch
       run: |
         echo "Running code on main branch"
@@ -44,13 +45,17 @@ jobs:
       id: compare
       run: |
         # Compare the results from both branches
-        diff pullautus_pr.png pullautus_main.png
-      continue-on-error: true
+        # install imagemagic to do the comparison ( Seems to work and already be included with ubuntu-latest)
+        sudo apt install imagemagick 
+        imagemagic compare -metric PSNR pullautus_main.png pullautus_pr.png difference.png
+    
+    - name: Upload results
+      uses: actions/upload-artifact@v4
+      with:
+        name: regression-results
+        path: |
+          pullautus_main.png
+          pullautus_pr.png
+          difference.png
+        overwrite: true # we need subsequent runs to overwrite the result
 
-    # - name: Check comparison result
-    #   if: steps.compare.outcome == 'failure'
-    #   run: |
-    #     echo "Results differ between PR branch and main"
-    #     exit 1
-    #   if: steps.compare.outcome == 'success'
-    #   run: echo "Results are the same between PR branch and main"

--- a/.github/workflows/regression.yml
+++ b/.github/workflows/regression.yml
@@ -18,8 +18,8 @@ jobs:
 
     - name: Download LAZ file
       env:
-        REGRESSION_LAZ_FILE_URL: ${{ secrets.REGRESSION_LAZ_FILE_URL }}
-      run: curl -L "$REGRESSION_LAZ_FILE_URL" -o test_file.laz
+        KP_TEST_LAZ_URL: ${{ vars.KP_TEST_LAZ_URL }}
+      run: curl -L "$KP_TEST_LAZ_URL" -o test_file.laz
 
     - name: Run code on PR branch
       id: run_pr_branch

--- a/.github/workflows/regression.yml
+++ b/.github/workflows/regression.yml
@@ -47,12 +47,12 @@ jobs:
     - name: Compare results (pngcomp)
       id: compare
       run: |
-        # Compare the results from both branches
+        # Compare the results from both branches, output results as step summary
         sudo apt install pngnq 
-        printf "\n\n##### Comparing without depressions:\n"
-        pngcomp pullautus_main.png pullautus_pr.png | tee pngcomp.txt
-        printf "\n\n##### Comparing with depressions:\n"
-        pngcomp pullautus_depr_main.png pullautus_depr_pr.png | tee pngcomp_depr.txt
+        printf "\n\n##### Comparing without depressions:\n" | tee -a $GITHUB_STEP_SUMMARY
+        pngcomp pullautus_main.png pullautus_pr.png | tee -a pngcomp.txt $GITHUB_STEP_SUMMARY
+        printf "\n\n##### Comparing with depressions:\n" | tee -a $GITHUB_STEP_SUMMARY
+        pngcomp pullautus_depr_main.png pullautus_depr_pr.png | tee -a pngcomp_depr.txt $GITHUB_STEP_SUMMARY
     
     - name: Upload results
       uses: actions/upload-artifact@v4
@@ -77,12 +77,12 @@ jobs:
         value_depr=$(sed -rn 's/Percentage correct pixels: ([0-9]+\.[0-9]+)$/\1/p' pngcomp_depr.txt)
 
         if (( $(echo "$value < 100.0" | bc -l) )); then
-          echo "Percentage of correct pixels (without depressions) is $value < 100%. Output has changed!";
+          echo "Percentage of correct pixels (without depressions) is $value < 100%. Output has changed!" | tee -a $GITHUB_STEP_SUMMARY
           exit 1
         fi
 
         if (( $(echo "$value_depr < 100.0" | bc -l) )); then
-          echo "Percentage of correct pixels (with depressions) is $value_depr < 100%. Output has changed!";
+          echo "Percentage of correct pixels (with depressions) is $value_depr < 100%. Output has changed!" | tee -a $GITHUB_STEP_SUMMARY
           exit 1
         fi
 

--- a/.github/workflows/regression.yml
+++ b/.github/workflows/regression.yml
@@ -31,18 +31,14 @@ jobs:
         mv pullautus_depr.png pullautus_depr_pr.png
         rm -rf temp/
 
-    - name: Checkout master branch
+    - name: Download, extract and run latest release
       run: |
-        git fetch origin master
-        git checkout master
-
-    - name: Run code on master branch
-      id: run_main_branch
-      run: |
-        echo "Running code on main branch"
-        cargo run --release -- test_file.laz
-        mv pullautus.png pullautus_main.png
-        mv pullautus_depr.png pullautus_depr_main.png
+        # in a new folder to make sure we have a clean environment
+        mkdir latest_release && cd latest_release
+        curl -L https://github.com/rphlo/karttapullautin/releases/latest/download/karttapullautin-x86_64-linux.tar.gz | tar xvz
+        ./pullauta ../test_file.laz
+        mv pullautus.png ../pullautus_main.png
+        mv pullautus_depr.png ../pullautus_depr_main.png
 
     - name: Compare results (pngcomp)
       id: compare

--- a/.github/workflows/regression.yml
+++ b/.github/workflows/regression.yml
@@ -1,0 +1,56 @@
+on:
+  pull_request:
+    branches: [ "master" ]
+
+name: "Regression"
+
+jobs:
+  compare-results:
+    runs-on: ubuntu-latest
+
+    steps:
+    - name: Checkout PR branch
+      uses: actions/checkout@v4
+      with:
+        fetch-depth: 2
+
+    - uses: dtolnay/rust-toolchain@stable
+
+    - name: Download LAZ file
+      env:
+        REGRESSION_LAZ_FILE_URL: ${{ secrets.REGRESSION_LAZ_FILE_URL }}
+      run: curl -L "$REGRESSION_LAZ_FILE_URL" -o test_file.laz
+
+    - name: Run code on PR branch
+      id: run_pr_branch
+      run: |
+        echo "Running code on PR branch"
+        cargo run --release -- test_file.laz
+        mv pullautus.png pullautus_pr.png
+
+    - name: Checkout main branch
+      run: |
+        git fetch origin main
+        git checkout main
+
+    - name: Run code on main branch
+      id: run_main_branch
+      run: |
+        echo "Running code on main branch"
+        cargo run --release -- test_file.laz
+        mv pullautus.png pullautus_main.png
+
+    - name: Compare results
+      id: compare
+      run: |
+        # Compare the results from both branches
+        diff pullautus_pr.png pullautus_main.png
+      continue-on-error: true
+
+    # - name: Check comparison result
+    #   if: steps.compare.outcome == 'failure'
+    #   run: |
+    #     echo "Results differ between PR branch and main"
+    #     exit 1
+    #   if: steps.compare.outcome == 'success'
+    #   run: echo "Results are the same between PR branch and main"


### PR DESCRIPTION
An attempt to create a CI workflow that can do some kind of regression test and compare the generate output map from the PR branch with the output of the `master` branch. Steps:

1. Download a LAZ input file for use for the regressions. I personally uploaded a file to google drive and stored the download link in the `REGRESSION_LAZ_FILE_URL` secret. You will need to do something similar to make this work.
2. Compile and run the program on the PR branch.
3. Checkout the `master` branch.
4. Compile and run the program on the `master` branch.
5. Compare the generated output map files. I tried using `imagemagick` but it has some memory limits when running in the GitHub runners, so in the end I ended up with [`pngcomp`](https://manpages.ubuntu.com/manpages/bionic/man1/pngcomp.1.html) which checks pixel-by-pixel and outputs some metrics.
6. Upload the metrics and generated files as artifacts (in case one want to inspect the files)
7. Check if some metric is below threshold for acceptance (currently set to fail if there is not a 100% overlap between the two maps), and fail the job if change is too big.