### PR TITLE
Feature/use path

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1070,7 +1070,6 @@ dependencies = [
  "las",
  "log",
  "rand",
- "regex",
  "rust-ini",
  "rustc-hash 2.0.0",
  "shapefile",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,7 +24,6 @@ imageproc = { version = "0.25.0", default-features = false, features = [
 
 las = { version = "0.9", features = ["laz"] }
 rand = "0.8.5"
-regex = "1"
 rust-ini = "0.21"
 rustc-hash = "2.0.0"
 shapefile = "0.6.0"

--- a/src/blocks.rs
+++ b/src/blocks.rs
@@ -4,13 +4,12 @@ use imageproc::filter::median_filter;
 use imageproc::rect::Rect;
 use log::info;
 use rustc_hash::FxHashMap as HashMap;
-use std::{error::Error, path::PathBuf};
+use std::{error::Error, path::Path};
 
 use crate::util::{read_lines, read_lines_no_alloc};
 
-pub fn blocks(thread: &String) -> Result<(), Box<dyn Error>> {
+pub fn blocks(tmpfolder: &Path) -> Result<(), Box<dyn Error>> {
     info!("Identifying blocks...");
-    let tmpfolder = PathBuf::from(format!("temp{}", thread));
     let xyz_file_in = tmpfolder.join("xyz2.xyz");
     let mut size: f64 = f64::NAN;
     let mut xstartxyz: f64 = f64::NAN;

--- a/src/canvas.rs
+++ b/src/canvas.rs
@@ -132,7 +132,7 @@ impl Canvas {
     }
 
     #[inline]
-    pub fn save_as(&mut self, filename: &str) {
+    pub fn save_as(&mut self, filename: &std::path::Path) {
         let d = self.data();
         let mut file = File::create(filename).unwrap();
         let bytes = d.as_bytes();
@@ -140,7 +140,7 @@ impl Canvas {
     }
 
     #[inline]
-    pub fn load_from(filename: &str) -> Canvas {
+    pub fn load_from(filename: &std::path::Path) -> Canvas {
         let data = Data::from_filename(filename).unwrap();
         let image = Image::from_encoded(data).unwrap();
         let mut c = Canvas::new(image.width(), image.height());

--- a/src/cliffs.rs
+++ b/src/cliffs.rs
@@ -5,13 +5,13 @@ use rand::prelude::*;
 use std::error::Error;
 use std::fs::File;
 use std::io::{BufWriter, Write};
-use std::path::PathBuf;
+use std::path::Path;
 
 use crate::config::Config;
 use crate::util::read_lines;
 use crate::util::read_lines_no_alloc;
 
-pub fn makecliffs(config: &Config, thread: &String) -> Result<(), Box<dyn Error>> {
+pub fn makecliffs(config: &Config, tmpfolder: &Path) -> Result<(), Box<dyn Error>> {
     info!("Identifying cliffs...");
 
     let &Config {
@@ -38,8 +38,6 @@ pub fn makecliffs(config: &Config, thread: &String) -> Result<(), Box<dyn Error>
 
     let mut hmin: f64 = f64::MAX;
     let mut hmax: f64 = f64::MIN;
-
-    let tmpfolder = PathBuf::from(&format!("temp{}", thread));
 
     let xyz_file_in = tmpfolder.join("xyztemp.xyz");
 

--- a/src/contours.rs
+++ b/src/contours.rs
@@ -3,14 +3,14 @@ use rustc_hash::FxHashMap as HashMap;
 use std::error::Error;
 use std::fs::File;
 use std::io::{BufWriter, Write};
-use std::path::PathBuf;
+use std::path::Path;
 
 use crate::config::Config;
 use crate::util::read_lines_no_alloc;
 
 pub fn xyz2contours(
     config: &Config,
-    thread: &String,
+    tmpfolder: &Path,
     cinterval: f64,
     xyzfilein: &str,
     xyzfileout: &str,
@@ -21,8 +21,6 @@ pub fn xyz2contours(
 
     let scalefactor = config.scalefactor;
     let water_class = &config.water_class;
-
-    let tmpfolder = PathBuf::from(format!("temp{}", thread));
 
     let mut xmin: f64 = f64::MAX;
     let mut xmax: f64 = f64::MIN;

--- a/src/knolls.rs
+++ b/src/knolls.rs
@@ -5,17 +5,15 @@ use rustc_hash::FxHashMap as HashMap;
 use std::error::Error;
 use std::fs::{self, File};
 use std::io::{BufWriter, Write};
-use std::path::PathBuf;
+use std::path::Path;
 
 use crate::config::Config;
 use crate::util::{read_lines, read_lines_no_alloc};
 
-pub fn dotknolls(config: &Config, thread: &String) -> Result<(), Box<dyn Error>> {
+pub fn dotknolls(config: &Config, tmpfolder: &Path) -> Result<(), Box<dyn Error>> {
     info!("Identifying dotknolls...");
 
     let scalefactor = config.scalefactor;
-
-    let tmpfolder = PathBuf::from(format!("temp{}", thread));
 
     let xyz_file_in = tmpfolder.join("xyz_knolls.xyz");
 
@@ -173,7 +171,7 @@ pub fn dotknolls(config: &Config, thread: &String) -> Result<(), Box<dyn Error>>
     info!("Done");
     Ok(())
 }
-pub fn knolldetector(config: &Config, thread: &String) -> Result<(), Box<dyn Error>> {
+pub fn knolldetector(config: &Config, tmpfolder: &Path) -> Result<(), Box<dyn Error>> {
     info!("Detecting knolls...");
     let scalefactor = config.scalefactor;
     let contour_interval = config.contour_interval;
@@ -181,7 +179,6 @@ pub fn knolldetector(config: &Config, thread: &String) -> Result<(), Box<dyn Err
     let halfinterval = contour_interval / 2.0 * scalefactor;
 
     let interval = 0.3 * scalefactor;
-    let tmpfolder = PathBuf::from(format!("temp{}", thread));
 
     let xyz_file_in = tmpfolder.join("xyz_03.xyz");
 
@@ -910,14 +907,12 @@ pub fn knolldetector(config: &Config, thread: &String) -> Result<(), Box<dyn Err
     Ok(())
 }
 
-pub fn xyzknolls(config: &Config, thread: &String) -> Result<(), Box<dyn Error>> {
+pub fn xyzknolls(config: &Config, tmpfolder: &Path) -> Result<(), Box<dyn Error>> {
     info!("Identifying knolls...");
     let scalefactor = config.scalefactor;
     let contour_interval = config.contour_interval;
 
     let interval = contour_interval / 2.0 * scalefactor;
-
-    let tmpfolder = PathBuf::from(format!("temp{}", thread));
 
     let xyz_file_in = tmpfolder.join("xyz_03.xyz");
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -4,6 +4,7 @@ use regex::Regex;
 use std::env;
 use std::fs;
 use std::path::Path;
+use std::path::PathBuf;
 use std::sync::Arc;
 use std::{thread, time};
 
@@ -58,20 +59,33 @@ fn main() {
 
     let batch: bool = config.batch;
 
-    let tmpfolder = format!("temp{}", thread);
+    let tmpfolder = PathBuf::from(format!("temp{}", thread));
     fs::create_dir_all(&tmpfolder).expect("Could not create tmp folder");
 
     let pnorthlinesangle = config.pnorthlinesangle;
     let pnorthlineswidth = config.pnorthlineswidth;
 
-    if command.is_empty() && Path::new(&format!("{}/vegetation.png", tmpfolder)).exists() && !batch
-    {
+    if command.is_empty() && tmpfolder.join("vegetation.png").exists() && !batch {
         info!("Rendering png map with depressions");
-        pullauta::render::render(&config, &thread, pnorthlinesangle, pnorthlineswidth, false)
-            .unwrap();
+        pullauta::render::render(
+            &config,
+            &thread,
+            &tmpfolder,
+            pnorthlinesangle,
+            pnorthlineswidth,
+            false,
+        )
+        .unwrap();
         info!("Rendering png map without depressions");
-        pullauta::render::render(&config, &thread, pnorthlinesangle, pnorthlineswidth, true)
-            .unwrap();
+        pullauta::render::render(
+            &config,
+            &thread,
+            &tmpfolder,
+            pnorthlinesangle,
+            pnorthlineswidth,
+            true,
+        )
+        .unwrap();
         info!("\nAll done!");
         return;
     }
@@ -127,12 +141,12 @@ fn main() {
     }
 
     if command == "blocks" {
-        pullauta::blocks::blocks(&thread).unwrap();
+        pullauta::blocks::blocks(&tmpfolder).unwrap();
         return;
     }
 
     if command == "dotknolls" {
-        pullauta::knolls::dotknolls(&config, &thread).unwrap();
+        pullauta::knolls::dotknolls(&config, &tmpfolder).unwrap();
         return;
     }
 
@@ -149,17 +163,17 @@ fn main() {
     }
 
     if command == "knolldetector" {
-        pullauta::knolls::knolldetector(&config, &thread).unwrap();
+        pullauta::knolls::knolldetector(&config, &tmpfolder).unwrap();
         return;
     }
 
     if command == "makecliffs" {
-        pullauta::cliffs::makecliffs(&config, &thread).unwrap();
+        pullauta::cliffs::makecliffs(&config, &tmpfolder).unwrap();
         return;
     }
 
     if command == "makevege" {
-        pullauta::vegetation::makevege(&config, &thread).unwrap();
+        pullauta::vegetation::makevege(&config, &tmpfolder).unwrap();
     }
 
     if command == "pngmerge" || command == "pngmergedepr" {
@@ -203,19 +217,19 @@ fn main() {
     }
 
     if command == "smoothjoin" {
-        pullauta::merge::smoothjoin(&config, &thread).unwrap();
+        pullauta::merge::smoothjoin(&config, &tmpfolder).unwrap();
     }
 
     if command == "xyzknolls" {
-        pullauta::knolls::xyzknolls(&config, &thread).unwrap();
+        pullauta::knolls::xyzknolls(&config, &tmpfolder).unwrap();
     }
 
     if command == "unzipmtk" {
-        pullauta::process::unzipmtk(&config, &thread, &args).unwrap();
+        pullauta::process::unzipmtk(&config, &tmpfolder, &args).unwrap();
     }
 
     if command == "mtkshaperender" {
-        pullauta::render::mtkshaperender(&config, &thread).unwrap();
+        pullauta::render::mtkshaperender(&config, &tmpfolder).unwrap();
     }
 
     if command == "xyz2contours" {
@@ -229,7 +243,7 @@ fn main() {
         }
         pullauta::contours::xyz2contours(
             &config,
-            &thread,
+            &tmpfolder,
             cinterval,
             &xyzfilein,
             &xyzfileout,
@@ -244,7 +258,8 @@ fn main() {
         let angle: f64 = args[0].parse::<f64>().unwrap();
         let nwidth: usize = args[1].parse::<usize>().unwrap();
         let nodepressions: bool = args.len() > 2 && args[2] == "nodepressions";
-        pullauta::render::render(&config, &thread, angle, nwidth, nodepressions).unwrap();
+        pullauta::render::render(&config, &thread, &tmpfolder, angle, nwidth, nodepressions)
+            .unwrap();
         return;
     }
 
@@ -282,7 +297,7 @@ fn main() {
     if zip_files_re.is_match(&command.to_lowercase()) {
         let mut zips: Vec<String> = vec![command];
         zips.extend(args);
-        pullauta::process::process_zip(&config, &thread, &zips).unwrap();
+        pullauta::process::process_zip(&config, &thread, &tmpfolder, &zips).unwrap();
         return;
     }
 
@@ -291,6 +306,6 @@ fn main() {
         if args.len() > 1 {
             norender = args[1].clone() == "norender";
         }
-        pullauta::process::process_tile(&config, &thread, &command, norender).unwrap();
+        pullauta::process::process_tile(&config, &thread, &tmpfolder, &command, norender).unwrap();
     }
 }

--- a/src/merge.rs
+++ b/src/merge.rs
@@ -505,7 +505,8 @@ pub fn dxfmerge(config: &Config) -> Result<(), Box<dyn Error>> {
 
 pub fn smoothjoin(config: &Config, thread: &String) -> Result<(), Box<dyn Error>> {
     info!("Smooth curves...");
-    let tmpfolder = format!("temp{}", thread);
+    let tmpfolder = PathBuf::from(format!("temp{}", thread));
+
     let &Config {
         scalefactor,
         inidotknolls,
@@ -524,13 +525,12 @@ pub fn smoothjoin(config: &Config, thread: &String) -> Result<(), Box<dyn Error>
     }
 
     let interval = halfinterval;
-    let path = format!("{}/xyz_knolls.xyz", tmpfolder);
-    let xyz_file_in = Path::new(&path);
+    let xyz_file_in = tmpfolder.join("xyz_knolls.xyz");
     let mut size: f64 = f64::NAN;
     let mut xstart: f64 = f64::NAN;
     let mut ystart: f64 = f64::NAN;
 
-    if let Ok(lines) = read_lines(xyz_file_in) {
+    if let Ok(lines) = read_lines(&xyz_file_in) {
         for (i, line) in lines.enumerate() {
             let ip = line.unwrap_or(String::new());
             let mut parts = ip.split(' ');
@@ -590,8 +590,7 @@ pub fn smoothjoin(config: &Config, thread: &String) -> Result<(), Box<dyn Error>
             steepness[i as usize][j as usize] = high - low;
         }
     }
-    let input_filename = &format!("{}/out.dxf", tmpfolder);
-    let input = Path::new(input_filename);
+    let input = tmpfolder.join("out.dxf");
     let data = fs::read_to_string(input).expect("Can not read input file");
     let data: Vec<&str> = data.split("POLYLINE").collect();
     let mut dxfheadtmp = data[0];
@@ -599,8 +598,7 @@ pub fn smoothjoin(config: &Config, thread: &String) -> Result<(), Box<dyn Error>
     dxfheadtmp = dxfheadtmp.split("HEADER").collect::<Vec<&str>>()[1];
     let dxfhead = &format!("HEADER{}ENDSEC", dxfheadtmp);
 
-    let output_filename = &format!("{}/out2.dxf", tmpfolder);
-    let output = Path::new(output_filename);
+    let output = tmpfolder.join("out2.dxf");
     let fp = File::create(output).expect("Unable to create file");
     let mut fp = BufWriter::new(fp);
 
@@ -611,18 +609,15 @@ pub fn smoothjoin(config: &Config, thread: &String) -> Result<(), Box<dyn Error>
     fp.write_all(b"\r\n  0\r\nSECTION\r\n  2\r\nENTITIES\r\n  0\r\n")
         .expect("Could not write file");
 
-    let depr_filename = &format!("{}/depressions.txt", tmpfolder);
-    let depr_output = Path::new(depr_filename);
+    let depr_output = tmpfolder.join("depressions.txt");
     let depr_fp = File::create(depr_output).expect("Unable to create file");
     let mut depr_fp = BufWriter::new(depr_fp);
 
-    let dotknoll_filename = &format!("{}/dotknolls.txt", tmpfolder);
-    let dotknoll_output = Path::new(dotknoll_filename);
+    let dotknoll_output = tmpfolder.join("dotknolls.txt");
     let dotknoll_fp = File::create(dotknoll_output).expect("Unable to create file");
     let mut dotknoll_fp = BufWriter::new(dotknoll_fp);
 
-    let knollhead_filename = &format!("{}/knollheads.txt", tmpfolder);
-    let knollhead_output = Path::new(knollhead_filename);
+    let knollhead_output = tmpfolder.join("knollheads.txt");
     let knollhead_fp = File::create(knollhead_output).expect("Unable to create file");
     let mut knollhead_fp = BufWriter::new(knollhead_fp);
 

--- a/src/merge.rs
+++ b/src/merge.rs
@@ -503,9 +503,8 @@ pub fn dxfmerge(config: &Config) -> Result<(), Box<dyn Error>> {
     Ok(())
 }
 
-pub fn smoothjoin(config: &Config, thread: &String) -> Result<(), Box<dyn Error>> {
+pub fn smoothjoin(config: &Config, tmpfolder: &Path) -> Result<(), Box<dyn Error>> {
     info!("Smooth curves...");
-    let tmpfolder = PathBuf::from(format!("temp{}", thread));
 
     let &Config {
         scalefactor,

--- a/src/process.rs
+++ b/src/process.rs
@@ -79,7 +79,7 @@ pub fn process_tile(
     skip_rendering: bool,
 ) -> Result<(), Box<dyn Error>> {
     let mut timing = Timing::start_now("process_tile");
-    let tmpfolder = format!("temp{}", thread);
+    let tmpfolder = PathBuf::from(format!("temp{}", thread));
     fs::create_dir_all(&tmpfolder).expect("Could not create tmp folder");
 
     let &Config {
@@ -141,7 +141,7 @@ pub fn process_tile(
         let mut rng = rand::thread_rng();
         let randdist = distributions::Bernoulli::new(thinfactor).unwrap();
 
-        let tmp_filename = format!("{}/xyztemp.xyz", tmpfolder);
+        let tmp_filename = tmpfolder.join("xyztemp.xyz");
         let tmp_file = File::create(tmp_filename).expect("Unable to create file");
         let mut tmp_fp = BufWriter::new(tmp_file);
 
@@ -165,11 +165,8 @@ pub fn process_tile(
         }
         tmp_fp.flush().unwrap();
     } else {
-        fs::copy(
-            Path::new(filename),
-            Path::new(&format!("{}/xyztemp.xyz", tmpfolder)),
-        )
-        .expect("Could not copy file to tmpfolder");
+        fs::copy(Path::new(filename), tmpfolder.join("xyztemp.xyz"))
+            .expect("Could not copy file to tmpfolder");
     }
     info!("{}Done", thread_name);
 
@@ -208,11 +205,8 @@ pub fn process_tile(
         .expect("contour generation failed");
     }
 
-    fs::copy(
-        format!("{}/xyz_03.xyz", tmpfolder),
-        format!("{}/xyz2.xyz", tmpfolder),
-    )
-    .expect("Could not copy file");
+    fs::copy(tmpfolder.join("xyz_03.xyz"), tmpfolder.join("xyz2.xyz"))
+        .expect("Could not copy file");
 
     let &Config {
         contour_interval,

--- a/src/process.rs
+++ b/src/process.rs
@@ -3,7 +3,6 @@ use las::{raw::Header, Reader};
 use log::info;
 use rand::distributions;
 use rand::prelude::*;
-use regex::Regex;
 use std::error::Error;
 use std::fs::{self, File};
 use std::io::{BufWriter, Write};
@@ -116,10 +115,7 @@ pub fn process_tile(
     info!("{}Preparing input file", thread_name);
 
     let mut skiplaz2txt: bool = false;
-    if Regex::new(r".xyz$")
-        .unwrap()
-        .is_match(&filename.to_lowercase())
-    {
+    if filename.to_lowercase().ends_with(".xyz") {
         if let Ok(lines) = read_lines(Path::new(filename)) {
             let mut i: u32 = 0;
             for line in lines {

--- a/src/render.rs
+++ b/src/render.rs
@@ -12,9 +12,9 @@ use std::error::Error;
 use std::f64::consts::PI;
 use std::fs::{self, File};
 use std::io::{BufWriter, Write};
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 
-pub fn mtkshaperender(config: &Config, thread: &String) -> Result<(), Box<dyn Error>> {
+pub fn mtkshaperender(config: &Config, tmpfolder: &Path) -> Result<(), Box<dyn Error>> {
     let scalefactor = config.scalefactor;
 
     let vectorconf = &config.vectorconf;
@@ -30,7 +30,6 @@ pub fn mtkshaperender(config: &Config, thread: &String) -> Result<(), Box<dyn Er
             .map(|x| x.to_string())
             .collect();
     }
-    let tmpfolder = PathBuf::from(format!("temp{}", thread));
     if !tmpfolder.join("vegetation.pgw").exists() {
         info!("Could not find vegetation file");
         return Ok(());
@@ -1103,6 +1102,7 @@ pub fn mtkshaperender(config: &Config, thread: &String) -> Result<(), Box<dyn Er
 pub fn render(
     config: &Config,
     thread: &String,
+    tmpfolder: &Path,
     angle_deg: f64,
     nwidth: usize,
     nodepressions: bool,
@@ -1111,7 +1111,6 @@ pub fn render(
 
     let scalefactor = config.scalefactor;
 
-    let tmpfolder = PathBuf::from(format!("temp{}", thread));
     let angle = -angle_deg / 180.0 * PI;
 
     // Draw vegetation ----------
@@ -1201,7 +1200,7 @@ pub fn render(
         }
     }
 
-    draw_curves(config, &mut img, thread, nodepressions, true).unwrap();
+    draw_curves(config, &mut img, tmpfolder, nodepressions, true).unwrap();
 
     // dotknolls----------
     let input = tmpfolder.join("dotknolls.dxf");
@@ -1517,7 +1516,7 @@ pub fn render(
 pub fn draw_curves(
     config: &Config,
     canvas: &mut ImageBuffer<Rgba<u8>, Vec<u8>>,
-    thread: &String,
+    tmpfolder: &Path,
     nodepressions: bool,
     draw_image: bool,
 ) -> Result<(), Box<dyn Error>> {
@@ -1534,8 +1533,6 @@ pub fn draw_curves(
         ..
     } = config;
     formlinesteepness *= scalefactor;
-
-    let tmpfolder = PathBuf::from(format!("temp{}", thread));
 
     let mut size: f64 = 0.0;
     let mut xstart: f64 = 0.0;

--- a/src/vegetation.rs
+++ b/src/vegetation.rs
@@ -8,15 +8,13 @@ use std::error::Error;
 use std::f32::consts::SQRT_2;
 use std::fs::File;
 use std::io::{BufWriter, Write};
-use std::path::{Path, PathBuf};
+use std::path::Path;
 
 use crate::config::{Config, Zone};
 use crate::util::{read_lines, read_lines_no_alloc};
 
-pub fn makevege(config: &Config, thread: &String) -> Result<(), Box<dyn Error>> {
+pub fn makevege(config: &Config, tmpfolder: &Path) -> Result<(), Box<dyn Error>> {
     info!("Generating vegetation...");
-
-    let tmpfolder = PathBuf::from(format!("temp{}", thread));
 
     let path = tmpfolder.join("xyz2.xyz");
     let xyz_file_in = Path::new(&path);

--- a/src/vegetation.rs
+++ b/src/vegetation.rs
@@ -8,7 +8,7 @@ use std::error::Error;
 use std::f32::consts::SQRT_2;
 use std::fs::File;
 use std::io::{BufWriter, Write};
-use std::path::Path;
+use std::path::{Path, PathBuf};
 
 use crate::config::{Config, Zone};
 use crate::util::{read_lines, read_lines_no_alloc};
@@ -16,9 +16,9 @@ use crate::util::{read_lines, read_lines_no_alloc};
 pub fn makevege(config: &Config, thread: &String) -> Result<(), Box<dyn Error>> {
     info!("Generating vegetation...");
 
-    let tmpfolder = format!("temp{}", thread);
+    let tmpfolder = PathBuf::from(format!("temp{}", thread));
 
-    let path = format!("{}/xyz2.xyz", tmpfolder);
+    let path = tmpfolder.join("xyz2.xyz");
     let xyz_file_in = Path::new(&path);
 
     let mut xstart: f64 = 0.0;
@@ -91,7 +91,7 @@ pub fn makevege(config: &Config, thread: &String) -> Result<(), Box<dyn Error>> 
     } = config;
     let greenshades = &config.greenshades;
 
-    let path = format!("{}/xyztemp.xyz", tmpfolder);
+    let path = tmpfolder.join("xyztemp.xyz");
     let xyz_file_in = Path::new(&path);
 
     let xmin = xstart;
@@ -419,23 +419,20 @@ pub fn makevege(config: &Config, thread: &String) -> Result<(), Box<dyn Error>> 
     }
 
     imgye2
-        .save(Path::new(&format!("{}/yellow.png", tmpfolder)))
+        .save(tmpfolder.join("yellow.png"))
         .expect("could not save output png");
     imggr1
-        .save(Path::new(&format!("{}/greens.png", tmpfolder)))
+        .save(tmpfolder.join("greens.png"))
         .expect("could not save output png");
 
-    let mut img =
-        image::open(Path::new(&format!("{}/greens.png", tmpfolder))).expect("Opening image failed");
-    let img2 =
-        image::open(Path::new(&format!("{}/yellow.png", tmpfolder))).expect("Opening image failed");
+    let mut img = image::open(tmpfolder.join("greens.png")).expect("Opening image failed");
+    let img2 = image::open(tmpfolder.join("yellow.png")).expect("Opening image failed");
     image::imageops::overlay(&mut img, &img2, 0, 0);
-    img.save(Path::new(&format!("{}/vegetation.png", tmpfolder)))
+    img.save(tmpfolder.join("vegetation.png"))
         .expect("could not save output png");
 
     if vege_bitmode {
-        let g_img = image::open(Path::new(&format!("{}/greens.png", tmpfolder)))
-            .expect("Opening image failed");
+        let g_img = image::open(tmpfolder.join("greens.png")).expect("Opening image failed");
         let mut g_img = g_img.to_rgb8();
         for pixel in g_img.pixels_mut() {
             let mut found = false;
@@ -451,17 +448,15 @@ pub fn makevege(config: &Config, thread: &String) -> Result<(), Box<dyn Error>> 
             }
         }
         g_img
-            .save(Path::new(&format!("{}/greens_bit.png", tmpfolder)))
+            .save(tmpfolder.join("greens_bit.png"))
             .expect("could not save output png");
-        let g_img = image::open(Path::new(&format!("{}/greens_bit.png", tmpfolder)))
-            .expect("Opening image failed");
+        let g_img = image::open(tmpfolder.join("greens_bit.png")).expect("Opening image failed");
         let g_img = g_img.to_luma8();
         g_img
-            .save(Path::new(&format!("{}/greens_bit.png", tmpfolder)))
+            .save(tmpfolder.join("greens_bit.png"))
             .expect("could not save output png");
 
-        let y_img = image::open(Path::new(&format!("{}/yellow.png", tmpfolder)))
-            .expect("Opening image failed");
+        let y_img = image::open(tmpfolder.join("yellow.png")).expect("Opening image failed");
         let mut y_img = y_img.to_rgba8();
         for pixel in y_img.pixels_mut() {
             if pixel[0] == ye2[0] && pixel[1] == ye2[1] && pixel[2] == ye2[2] && pixel[3] == ye2[3]
@@ -472,22 +467,20 @@ pub fn makevege(config: &Config, thread: &String) -> Result<(), Box<dyn Error>> 
             }
         }
         y_img
-            .save(Path::new(&format!("{}/yellow_bit.png", tmpfolder)))
+            .save(tmpfolder.join("yellow_bit.png"))
             .expect("could not save output png");
-        let y_img = image::open(Path::new(&format!("{}/yellow_bit.png", tmpfolder)))
-            .expect("Opening image failed");
+        let y_img = image::open(tmpfolder.join("yellow_bit.png")).expect("Opening image failed");
         let y_img = y_img.to_luma_alpha8();
         y_img
-            .save(Path::new(&format!("{}/yellow_bit.png", tmpfolder)))
+            .save(tmpfolder.join("yellow_bit.png"))
             .expect("could not save output png");
 
-        let mut img_bit = image::open(Path::new(&format!("{}/greens_bit.png", tmpfolder)))
-            .expect("Opening image failed");
-        let img_bit2 = image::open(Path::new(&format!("{}/yellow_bit.png", tmpfolder)))
-            .expect("Opening image failed");
+        let mut img_bit =
+            image::open(tmpfolder.join("greens_bit.png")).expect("Opening image failed");
+        let img_bit2 = image::open(tmpfolder.join("yellow_bit.png")).expect("Opening image failed");
         image::imageops::overlay(&mut img_bit, &img_bit2, 0, 0);
         img_bit
-            .save(Path::new(&format!("{}/vegetation_bit.png", tmpfolder)))
+            .save(tmpfolder.join("vegetation_bit.png"))
             .expect("could not save output png");
     }
 
@@ -521,9 +514,7 @@ pub fn makevege(config: &Config, thread: &String) -> Result<(), Box<dyn Error>> 
         .expect("Can not read file");
     }
 
-    let path = format!("{}/xyz2.xyz", tmpfolder);
-    let xyz_file_in = Path::new(&path);
-
+    let xyz_file_in = tmpfolder.join("xyz2.xyz");
     read_lines_no_alloc(xyz_file_in, |line| {
         let mut parts = line.split(' ');
         let x: f64 = parts.next().unwrap().parse::<f64>().unwrap();
@@ -541,7 +532,7 @@ pub fn makevege(config: &Config, thread: &String) -> Result<(), Box<dyn Error>> 
     .expect("Can not read file");
 
     imgwater
-        .save(Path::new(&format!("{}/blueblack.png", tmpfolder)))
+        .save(tmpfolder.join("blueblack.png"))
         .expect("could not save output png");
 
     let underg = Rgba([64, 121, 0, 255]);
@@ -668,15 +659,14 @@ pub fn makevege(config: &Config, thread: &String) -> Result<(), Box<dyn Error>> 
         x += bf32 * step;
     }
     imgug
-        .save(Path::new(&format!("{}/undergrowth.png", tmpfolder)))
+        .save(tmpfolder.join("undergrowth.png"))
         .expect("could not save output png");
     let img_ug_bit_b = median_filter(&img_ug_bit, (bf32 * step) as u32, (bf32 * step) as u32);
     img_ug_bit_b
-        .save(Path::new(&format!("{}/undergrowth_bit.png", tmpfolder)))
+        .save(tmpfolder.join("undergrowth_bit.png"))
         .expect("could not save output png");
 
-    let ugpgw = File::create(Path::new(&format!("{}/undergrowth.pgw", tmpfolder)))
-        .expect("Unable to create file");
+    let ugpgw = File::create(tmpfolder.join("undergrowth.pgw")).expect("Unable to create file");
     let mut ugpgw = BufWriter::new(ugpgw);
     write!(
         &mut ugpgw,
@@ -688,8 +678,7 @@ pub fn makevege(config: &Config, thread: &String) -> Result<(), Box<dyn Error>> 
     )
     .expect("Cannot write pgw file");
 
-    let vegepgw = File::create(Path::new(&format!("{}/vegetation.pgw", tmpfolder)))
-        .expect("Unable to create file");
+    let vegepgw = File::create(tmpfolder.join("vegetation.pgw")).expect("Unable to create file");
     let mut vegepgw = BufWriter::new(vegepgw);
     write!(
         &mut vegepgw,


### PR DESCRIPTION
Instead of using `format!()` to construct file paths, use the `Path` and `PathBuf` from the standard library. And instead of always constructing the `tmpfolder` using the thread in all the processing steps, take it as a parameter and define it in the high-level caller :100:  This reduces confusion and decouples the processing steps from the `thread` information. No performance gains but it makes the code easier to reason about.

Also removed the use of `regex` and replaced it with simple string comparison operations and a try to parse as `usize`. 