### PR TITLE
Feature/memory cache

### DIFF
--- a/pullauta.default.ini
+++ b/pullauta.default.ini
@@ -229,3 +229,12 @@ contoursonly=0
 cliffsonly=0
 # Only one of vegeonly contoursonly and cliffsonly can be set at a time
 
+
+#------------------------------------------------------#
+#            EXPERIMENTAL OPTIONS                      #
+#----------------------------------------------------- #
+
+# Set experimental_cache_input_files to 1 to cache the input files in memory to speed up the processing.
+# This is useful when the input files are small enough to fit in memory.
+# As an example, a 180 MB LAZ file will take about 1.0 GB of memory when cached.
+experimental_cache_input_files=0

--- a/pullauta.default.ini
+++ b/pullauta.default.ini
@@ -237,4 +237,4 @@ cliffsonly=0
 # Set experimental_cache_input_files to 1 to cache the input files in memory to speed up the processing.
 # This is useful when the input files are small enough to fit in memory.
 # As an example, a 180 MB LAZ file will take about 1.0 GB of memory when cached.
-experimental_cache_input_files=0
+experimental_cache_input_files=1

--- a/src/blocks.rs
+++ b/src/blocks.rs
@@ -8,7 +8,7 @@ use std::{error::Error, path::Path};
 
 use crate::{
     config::Config,
-    util::{read_lines, read_lines_no_alloc, read_xyztemp_input_file},
+    util::{read_lines, read_xyztemp_input_file},
 };
 
 pub fn blocks(config: &Config, tmpfolder: &Path) -> Result<(), Box<dyn Error>> {
@@ -38,11 +38,10 @@ pub fn blocks(config: &Config, tmpfolder: &Path) -> Result<(), Box<dyn Error>> {
     }
 
     let mut xyz: HashMap<(u64, u64), f64> = HashMap::default();
-    read_lines_no_alloc(xyz_file_in, |line| {
-        let mut parts = line.split(' ');
-        let x: f64 = parts.next().unwrap().parse::<f64>().unwrap();
-        let y: f64 = parts.next().unwrap().parse::<f64>().unwrap();
-        let h: f64 = parts.next().unwrap().parse::<f64>().unwrap();
+    read_xyztemp_input_file(&xyz_file_in, config, |p, _| {
+        let x = p.x;
+        let y = p.y;
+        let h = p.z;
 
         let xx = ((x - xstartxyz) / size).floor() as u64;
         let yy = ((y - ystartxyz) / size).floor() as u64;

--- a/src/blocks.rs
+++ b/src/blocks.rs
@@ -8,7 +8,7 @@ use std::{error::Error, path::Path};
 
 use crate::{
     config::Config,
-    util::{read_lines, read_xyztemp_input_file},
+    util::{read_lines, read_xyz_file},
 };
 
 pub fn blocks(config: &Config, tmpfolder: &Path) -> Result<(), Box<dyn Error>> {
@@ -38,7 +38,7 @@ pub fn blocks(config: &Config, tmpfolder: &Path) -> Result<(), Box<dyn Error>> {
     }
 
     let mut xyz: HashMap<(u64, u64), f64> = HashMap::default();
-    read_xyztemp_input_file(&xyz_file_in, config, |p, _| {
+    read_xyz_file(&xyz_file_in, config, |p, _| {
         let x = p.x;
         let y = p.y;
         let h = p.z;
@@ -63,7 +63,7 @@ pub fn blocks(config: &Config, tmpfolder: &Path) -> Result<(), Box<dyn Error>> {
     let white = Rgba([255, 255, 255, 255]);
 
     let xyz_file_in = tmpfolder.join("xyztemp.xyz");
-    read_xyztemp_input_file(&xyz_file_in, config, |p, m| {
+    read_xyz_file(&xyz_file_in, config, |p, m| {
         let x = p.x;
         let y = p.y;
         let h = p.z;

--- a/src/blocks.rs
+++ b/src/blocks.rs
@@ -68,6 +68,7 @@ pub fn blocks(config: &Config, tmpfolder: &Path) -> Result<(), Box<dyn Error>> {
         let x = p.x;
         let y = p.y;
         let h = p.z;
+        let m = m.expect("metadata missing");
         let r3 = m.classification;
         let r4 = m.number_of_returns;
         let r5 = m.return_number;

--- a/src/cliffs.rs
+++ b/src/cliffs.rs
@@ -10,7 +10,6 @@ use std::path::Path;
 
 use crate::config::Config;
 use crate::util::read_lines;
-use crate::util::read_lines_no_alloc;
 use crate::util::read_xyztemp_input_file;
 use crate::vec2d::Vec2D;
 
@@ -92,11 +91,10 @@ pub fn makecliffs(config: &Config, tmpfolder: &Path) -> Result<(), Box<dyn Error
         f64::NAN,
     );
 
-    read_lines_no_alloc(xyz_file_in, |line| {
-        let mut parts = line.split(' ');
-        let x: f64 = parts.next().unwrap().parse::<f64>().unwrap();
-        let y: f64 = parts.next().unwrap().parse::<f64>().unwrap();
-        let h: f64 = parts.next().unwrap().parse::<f64>().unwrap();
+    read_xyztemp_input_file(&xyz_file_in, config, |p, _| {
+        let x = p.x;
+        let y = p.y;
+        let h = p.z;
 
         let xx = ((x - xstart) / size).floor() as usize;
         let yy = ((y - ystart) / size).floor() as usize;
@@ -335,12 +333,11 @@ pub fn makecliffs(config: &Config, tmpfolder: &Path) -> Result<(), Box<dyn Error
     );
 
     let xyz_file_in = tmpfolder.join("xyz2.xyz");
-    read_lines_no_alloc(&xyz_file_in, |line| {
+    read_xyztemp_input_file(&xyz_file_in, config, |p, _| {
         if cliff_thin == 1.0 || rng.sample(randdist) {
-            let mut parts = line.split(' ');
-            let x: f64 = parts.next().unwrap().parse::<f64>().unwrap();
-            let y: f64 = parts.next().unwrap().parse::<f64>().unwrap();
-            let h: f64 = parts.next().unwrap().parse::<f64>().unwrap();
+            let x = p.x;
+            let y = p.y;
+            let h = p.z;
 
             list_alt[(
                 ((x - xmin).floor() / 3.0) as usize,

--- a/src/cliffs.rs
+++ b/src/cliffs.rs
@@ -10,7 +10,7 @@ use std::path::Path;
 
 use crate::config::Config;
 use crate::util::read_lines;
-use crate::util::read_xyztemp_input_file;
+use crate::util::read_xyz_file;
 use crate::vec2d::Vec2D;
 
 pub fn makecliffs(config: &Config, tmpfolder: &Path) -> Result<(), Box<dyn Error>> {
@@ -39,7 +39,7 @@ pub fn makecliffs(config: &Config, tmpfolder: &Path) -> Result<(), Box<dyn Error
     let mut ymax: f64 = f64::MIN;
 
     let xyz_file_in = tmpfolder.join("xyztemp.xyz");
-    read_xyztemp_input_file(&xyz_file_in, config, |p, _| {
+    read_xyz_file(&xyz_file_in, config, |p, _| {
         let x = p.x;
         let y = p.y;
 
@@ -91,7 +91,7 @@ pub fn makecliffs(config: &Config, tmpfolder: &Path) -> Result<(), Box<dyn Error
         f64::NAN,
     );
 
-    read_xyztemp_input_file(&xyz_file_in, config, |p, _| {
+    read_xyz_file(&xyz_file_in, config, |p, _| {
         let x = p.x;
         let y = p.y;
         let h = p.z;
@@ -152,7 +152,7 @@ pub fn makecliffs(config: &Config, tmpfolder: &Path) -> Result<(), Box<dyn Error
     let mut rng = rand::thread_rng();
     let randdist = distributions::Bernoulli::new(cliff_thin).unwrap();
 
-    read_xyztemp_input_file(&xyz_file_in, config, |p, m| {
+    read_xyz_file(&xyz_file_in, config, |p, m| {
         if cliff_thin == 1.0 || rng.sample(randdist) {
             let m = m.expect("metadata missing");
             if m.classification == 2 {
@@ -333,7 +333,7 @@ pub fn makecliffs(config: &Config, tmpfolder: &Path) -> Result<(), Box<dyn Error
     );
 
     let xyz_file_in = tmpfolder.join("xyz2.xyz");
-    read_xyztemp_input_file(&xyz_file_in, config, |p, _| {
+    read_xyz_file(&xyz_file_in, config, |p, _| {
         if cliff_thin == 1.0 || rng.sample(randdist) {
             let x = p.x;
             let y = p.y;

--- a/src/cliffs.rs
+++ b/src/cliffs.rs
@@ -156,6 +156,7 @@ pub fn makecliffs(config: &Config, tmpfolder: &Path) -> Result<(), Box<dyn Error
 
     read_xyztemp_input_file(&xyz_file_in, config, |p, m| {
         if cliff_thin == 1.0 || rng.sample(randdist) {
+            let m = m.expect("metadata missing");
             if m.classification == 2 {
                 list_alt[(
                     ((p.x - xmin).floor() / 3.0) as usize,

--- a/src/config.rs
+++ b/src/config.rs
@@ -7,7 +7,7 @@ pub struct Config {
     pub batch: bool,
     pub processes: u64,
 
-    pub cache_input_points: bool,
+    pub experimental_cache_input_files: bool,
 
     // only one can be set at a time
     pub vegeonly: bool,
@@ -154,6 +154,8 @@ impl Config {
         let pnorthlineswidth: usize = parse_typed(gs, "northlineswidth", 0);
 
         let processes: u64 = gs.get("processes").unwrap().parse::<u64>().unwrap();
+        let experimental_cache_input_files: bool =
+            gs.get("experimental_cache_input_files").unwrap_or("0") == "1";
 
         let lazfolder = gs.get("lazfolder").unwrap_or("").to_string();
         let batchoutfolder = gs.get("batchoutfolder").unwrap_or("").to_string();
@@ -329,7 +331,7 @@ impl Config {
         Ok(Self {
             batch: gs.get("batch").unwrap() == "1",
             processes,
-            cache_input_points: true, // TODO
+            experimental_cache_input_files,
             vegeonly,
             cliffsonly,
             contoursonly,

--- a/src/config.rs
+++ b/src/config.rs
@@ -7,6 +7,8 @@ pub struct Config {
     pub batch: bool,
     pub processes: u64,
 
+    pub cache_input_points: bool,
+
     // only one can be set at a time
     pub vegeonly: bool,
     pub cliffsonly: bool,
@@ -327,6 +329,7 @@ impl Config {
         Ok(Self {
             batch: gs.get("batch").unwrap() == "1",
             processes,
+            cache_input_points: true, // TODO
             vegeonly,
             cliffsonly,
             contoursonly,

--- a/src/contours.rs
+++ b/src/contours.rs
@@ -6,7 +6,7 @@ use std::io::{BufWriter, Write};
 use std::path::Path;
 
 use crate::config::Config;
-use crate::util::{read_lines_no_alloc, read_xyztemp_input_file};
+use crate::util::{read_lines_no_alloc, read_xyz_file};
 use crate::vec2d::Vec2D;
 
 pub fn xyz2contours(
@@ -34,7 +34,7 @@ pub fn xyz2contours(
 
     let water_class = water_class.parse::<u8>().unwrap();
     let xyz_file_in = tmpfolder.join(xyzfilein);
-    read_xyztemp_input_file(&xyz_file_in, config, |p, m| {
+    read_xyz_file(&xyz_file_in, config, |p, m| {
         if m.is_some_and(|m| m.classification == 2 || m.classification == water_class) || !ground {
             let x = p.x;
             let y = p.y;
@@ -76,7 +76,7 @@ pub fn xyz2contours(
     // a two-dimensional vector of (sum, count) pairs for computing averages
     let mut list_alt = Vec2D::new(w + 2, h + 2, (0f64, 0usize));
 
-    read_xyztemp_input_file(&xyz_file_in, config, |p, m| {
+    read_xyz_file(&xyz_file_in, config, |p, m| {
         if m.is_some_and(|m| m.classification == 2 || m.classification == water_class) || !ground {
             let x = p.x;
             let y = p.y;

--- a/src/knolls.rs
+++ b/src/knolls.rs
@@ -8,7 +8,7 @@ use std::io::{BufWriter, Write};
 use std::path::Path;
 
 use crate::config::Config;
-use crate::util::{read_lines, read_lines_no_alloc, read_xyztemp_input_file};
+use crate::util::{read_lines, read_lines_no_alloc, read_xyz_file};
 
 pub fn dotknolls(config: &Config, tmpfolder: &Path) -> Result<(), Box<dyn Error>> {
     info!("Identifying dotknolls...");
@@ -209,7 +209,7 @@ pub fn knolldetector(config: &Config, tmpfolder: &Path) -> Result<(), Box<dyn Er
     let mut xmin: u64 = u64::MAX;
     let mut ymin: u64 = u64::MAX;
     let mut xyz: HashMap<(u64, u64), f64> = HashMap::default();
-    read_xyztemp_input_file(&xyz_file_in, config, |p, _| {
+    read_xyz_file(&xyz_file_in, config, |p, _| {
         let x = p.x;
         let y = p.y;
         let h = p.z;
@@ -939,7 +939,7 @@ pub fn xyzknolls(config: &Config, tmpfolder: &Path) -> Result<(), Box<dyn Error>
     let mut xmax: u64 = 0;
     let mut ymax: u64 = 0;
     let mut xyz: HashMap<(u64, u64), f64> = HashMap::default();
-    read_xyztemp_input_file(&xyz_file_in, config, |p, _| {
+    read_xyz_file(&xyz_file_in, config, |p, _| {
         let xx = ((p.x - xstart) / size).floor() as u64;
         let yy = ((p.y - ystart) / size).floor() as u64;
         xyz.insert((xx, yy), p.z);

--- a/src/knolls.rs
+++ b/src/knolls.rs
@@ -8,7 +8,7 @@ use std::io::{BufWriter, Write};
 use std::path::Path;
 
 use crate::config::Config;
-use crate::util::{read_lines, read_lines_no_alloc};
+use crate::util::{read_lines, read_lines_no_alloc, read_xyztemp_input_file};
 
 pub fn dotknolls(config: &Config, tmpfolder: &Path) -> Result<(), Box<dyn Error>> {
     info!("Identifying dotknolls...");
@@ -209,11 +209,10 @@ pub fn knolldetector(config: &Config, tmpfolder: &Path) -> Result<(), Box<dyn Er
     let mut xmin: u64 = u64::MAX;
     let mut ymin: u64 = u64::MAX;
     let mut xyz: HashMap<(u64, u64), f64> = HashMap::default();
-    read_lines_no_alloc(xyz_file_in, |line| {
-        let mut parts = line.split(' ');
-        let x: f64 = parts.next().unwrap().parse::<f64>().unwrap();
-        let y: f64 = parts.next().unwrap().parse::<f64>().unwrap();
-        let h: f64 = parts.next().unwrap().parse::<f64>().unwrap();
+    read_xyztemp_input_file(&xyz_file_in, config, |p, _| {
+        let x = p.x;
+        let y = p.y;
+        let h = p.z;
 
         let xx = ((x - xstart) / size).floor() as u64;
         let yy = ((y - ystart) / size).floor() as u64;
@@ -940,15 +939,10 @@ pub fn xyzknolls(config: &Config, tmpfolder: &Path) -> Result<(), Box<dyn Error>
     let mut xmax: u64 = 0;
     let mut ymax: u64 = 0;
     let mut xyz: HashMap<(u64, u64), f64> = HashMap::default();
-    read_lines_no_alloc(&xyz_file_in, |line| {
-        let mut parts = line.split(' ');
-        let x: f64 = parts.next().unwrap().parse::<f64>().unwrap();
-        let y: f64 = parts.next().unwrap().parse::<f64>().unwrap();
-        let h: f64 = parts.next().unwrap().parse::<f64>().unwrap();
-
-        let xx = ((x - xstart) / size).floor() as u64;
-        let yy = ((y - ystart) / size).floor() as u64;
-        xyz.insert((xx, yy), h);
+    read_xyztemp_input_file(&xyz_file_in, config, |p, _| {
+        let xx = ((p.x - xstart) / size).floor() as u64;
+        let yy = ((p.y - ystart) / size).floor() as u64;
+        xyz.insert((xx, yy), p.z);
         if xmax < xx {
             xmax = xx;
         }

--- a/src/main.rs
+++ b/src/main.rs
@@ -144,7 +144,7 @@ fn main() {
     }
 
     if command == "blocks" {
-        pullauta::blocks::blocks(&tmpfolder).unwrap();
+        pullauta::blocks::blocks(&config, &tmpfolder).unwrap();
         return;
     }
 

--- a/src/merge.rs
+++ b/src/merge.rs
@@ -7,7 +7,7 @@ use std::io::{BufWriter, Write};
 use std::path::{Path, PathBuf};
 
 use crate::config::Config;
-use crate::util::{read_lines, read_lines_no_alloc};
+use crate::util::{read_lines, read_xyztemp_input_file};
 use crate::vec2d::Vec2D;
 
 fn merge_png(
@@ -551,11 +551,10 @@ pub fn smoothjoin(config: &Config, tmpfolder: &Path) -> Result<(), Box<dyn Error
     let mut ymax: u64 = u64::MIN;
     let mut xyz: HashMap<(u64, u64), f64> = HashMap::default();
 
-    read_lines_no_alloc(xyz_file_in, |line| {
-        let mut parts = line.split(' ');
-        let x: f64 = parts.next().unwrap().parse::<f64>().unwrap();
-        let y: f64 = parts.next().unwrap().parse::<f64>().unwrap();
-        let h: f64 = parts.next().unwrap().parse::<f64>().unwrap();
+    read_xyztemp_input_file(&xyz_file_in, config, |p, _| {
+        let x = p.x;
+        let y = p.y;
+        let h = p.z;
 
         let xx = ((x - xstart) / size).floor() as u64;
         let yy = ((y - ystart) / size).floor() as u64;

--- a/src/merge.rs
+++ b/src/merge.rs
@@ -7,7 +7,7 @@ use std::io::{BufWriter, Write};
 use std::path::{Path, PathBuf};
 
 use crate::config::Config;
-use crate::util::{read_lines, read_xyztemp_input_file};
+use crate::util::{read_lines, read_xyz_file};
 use crate::vec2d::Vec2D;
 
 fn merge_png(
@@ -551,7 +551,7 @@ pub fn smoothjoin(config: &Config, tmpfolder: &Path) -> Result<(), Box<dyn Error
     let mut ymax: u64 = u64::MIN;
     let mut xyz: HashMap<(u64, u64), f64> = HashMap::default();
 
-    read_xyztemp_input_file(&xyz_file_in, config, |p, _| {
+    read_xyz_file(&xyz_file_in, config, |p, _| {
         let x = p.x;
         let y = p.y;
         let h = p.z;

--- a/src/process.rs
+++ b/src/process.rs
@@ -301,7 +301,7 @@ pub fn process_tile(
     if !vegeonly && !contoursonly && !cliffsonly && config.detectbuildings {
         info!("{}Detecting buildings", thread_name);
         timing.start_section("detecting buildings");
-        blocks::blocks(tmpfolder).unwrap();
+        blocks::blocks(config, tmpfolder).unwrap();
     }
     if !skip_rendering && !vegeonly && !contoursonly && !cliffsonly {
         info!("{}Rendering png map with depressions", thread_name);

--- a/src/render.rs
+++ b/src/render.rs
@@ -1,6 +1,6 @@
 use crate::canvas::Canvas;
 use crate::config::Config;
-use crate::util::{read_lines, read_xyztemp_input_file};
+use crate::util::{read_lines, read_xyz_file};
 use image::ImageBuffer;
 use image::Rgba;
 use imageproc::drawing::{draw_filled_circle_mut, draw_line_segment_mut};
@@ -1568,7 +1568,7 @@ pub fn draw_curves(
 
         let mut xyz: HashMap<(usize, usize), f64> = HashMap::default();
 
-        read_xyztemp_input_file(&xyz_file_in, config, |p, _| {
+        read_xyz_file(&xyz_file_in, config, |p, _| {
             let x = p.x;
             let y = p.y;
             let h = p.z;

--- a/src/render.rs
+++ b/src/render.rs
@@ -1,6 +1,6 @@
 use crate::canvas::Canvas;
 use crate::config::Config;
-use crate::util::{read_lines, read_lines_no_alloc};
+use crate::util::{read_lines, read_xyztemp_input_file};
 use image::ImageBuffer;
 use image::Rgba;
 use imageproc::drawing::{draw_filled_circle_mut, draw_line_segment_mut};
@@ -1568,11 +1568,10 @@ pub fn draw_curves(
 
         let mut xyz: HashMap<(usize, usize), f64> = HashMap::default();
 
-        read_lines_no_alloc(xyz_file_in, |line| {
-            let mut parts = line.split(' ');
-            let x: f64 = parts.next().unwrap().parse::<f64>().unwrap();
-            let y: f64 = parts.next().unwrap().parse::<f64>().unwrap();
-            let h: f64 = parts.next().unwrap().parse::<f64>().unwrap();
+        read_xyztemp_input_file(&xyz_file_in, config, |p, _| {
+            let x = p.x;
+            let y = p.y;
+            let h = p.z;
 
             let xx = ((x - xstart) / size).floor() as usize;
             let yy = ((y - ystart) / size).floor() as usize;

--- a/src/util.rs
+++ b/src/util.rs
@@ -118,16 +118,21 @@ pub fn read_xyztemp_input_file(
 
     debug!("Reading points from {}", filename.display());
     let (mut point_locations, mut point_metadata) = (Vec::new(), Vec::new());
+    let mut has_metadata = None;
     read_lines_no_alloc(filename, |line| {
-        let mut parts = line.trim().split(' ');
+        let mut parts = line.trim().split(' ').peekable();
 
         let x = parts.next().unwrap().parse::<f64>().unwrap();
         let y = parts.next().unwrap().parse::<f64>().unwrap();
         let z = parts.next().unwrap().parse::<f64>().unwrap();
 
-        // if we have metadata, parse it
-        let m = if let Some(c) = parts.next() {
-            let classification = c.parse::<u8>().unwrap();
+        // if we dont have metadata information yet, check if there is any
+        if has_metadata.is_none() {
+            has_metadata = Some(parts.peek().is_some());
+        }
+
+        let m = if has_metadata.expect("metadata should be set on first line") {
+            let classification = parts.next().unwrap().parse::<u8>().unwrap();
             let number_of_returns = parts.next().unwrap().parse::<u8>().unwrap();
             let return_number = parts.next().unwrap().parse::<u8>().unwrap();
             let intensity = parts.next().unwrap().parse::<u16>().unwrap();

--- a/src/util.rs
+++ b/src/util.rs
@@ -94,7 +94,7 @@ pub fn read_xyztemp_input_file(
     config: &Config,
     mut callback: impl FnMut(&PointLocation, Option<&PointMetadata>),
 ) -> Result<(), Box<dyn std::error::Error>> {
-    let should_cache = config.cache_input_points;
+    let should_cache = config.experimental_cache_input_files;
 
     if should_cache {
         if let Some(cached_points) = POINT_CACHE

--- a/src/vegetation.rs
+++ b/src/vegetation.rs
@@ -9,7 +9,7 @@ use std::f32::consts::SQRT_2;
 use std::path::Path;
 
 use crate::config::{Config, Zone};
-use crate::util::{read_lines, read_lines_no_alloc};
+use crate::util::{read_lines, read_lines_no_alloc, read_xyztemp_input_file};
 
 pub fn makevege(config: &Config, tmpfolder: &Path) -> Result<(), Box<dyn Error>> {
     info!("Generating vegetation...");
@@ -97,15 +97,14 @@ pub fn makevege(config: &Config, tmpfolder: &Path) -> Result<(), Box<dyn Error>>
     let mut noyhit: HashMap<(u64, u64), u64> = HashMap::default();
 
     let mut i = 0;
-    read_lines_no_alloc(&xyz_file_in, |line| {
+    read_xyztemp_input_file(&xyz_file_in, config, |p, m| {
         if vegethin == 0 || ((i + 1) as u32) % vegethin == 0 {
-            let mut parts = line.trim().split(' ');
-            let x: f64 = parts.next().unwrap().parse::<f64>().unwrap();
-            let y: f64 = parts.next().unwrap().parse::<f64>().unwrap();
-            let h: f64 = parts.next().unwrap().parse::<f64>().unwrap();
-            let r3 = parts.next().unwrap();
-            let r4 = parts.next().unwrap();
-            let r5 = parts.next().unwrap();
+            let x = p.x;
+            let y = p.y;
+            let h = p.z;
+            let r3 = m.classification;
+            let r4 = m.number_of_returns;
+            let r5 = m.return_number;
 
             if xmax < x {
                 xmax = x;
@@ -122,7 +121,7 @@ pub fn makevege(config: &Config, tmpfolder: &Path) -> Result<(), Box<dyn Error>>
                 let xx = ((x - xmin) / 3.0).floor() as u64;
                 let yy = ((y - ymin) / 3.0).floor() as u64;
 
-                if r3 == "2"
+                if r3 == 2
                     || h < yellowheight
                         + *xyz
                             .get(&(
@@ -132,7 +131,7 @@ pub fn makevege(config: &Config, tmpfolder: &Path) -> Result<(), Box<dyn Error>>
                             .unwrap_or(&0.0)
                 {
                     *yhit.entry((xx, yy)).or_insert(0) += 1;
-                } else if r4 == "1" && r5 == "1" {
+                } else if r4 == 1 && r5 == 1 {
                     *noyhit.entry((xx, yy)).or_insert(0) += yellowfirstlast;
                 } else {
                     *noyhit.entry((xx, yy)).or_insert(0) += 1;
@@ -155,20 +154,17 @@ pub fn makevege(config: &Config, tmpfolder: &Path) -> Result<(), Box<dyn Error>>
     let step: f32 = 6.0;
 
     let mut i = 0;
-    read_lines_no_alloc(&xyz_file_in, |line| {
+    read_xyztemp_input_file(&xyz_file_in, config, |p, m| {
         if vegethin == 0 || ((i + 1) as u32) % vegethin == 0 {
-            let mut parts = line.trim().split(' ');
-
-            // parse the parts of the line
-            let x: f64 = parts.next().unwrap().parse::<f64>().unwrap();
-            let y: f64 = parts.next().unwrap().parse::<f64>().unwrap();
-            let h: f64 = parts.next().unwrap().parse::<f64>().unwrap() - zoffset;
-            let r3 = parts.next().unwrap();
-            let r4 = parts.next().unwrap();
-            let r5 = parts.next().unwrap();
+            let x = p.x;
+            let y = p.y;
+            let h = p.z - zoffset;
+            let r3 = m.classification;
+            let r4 = m.number_of_returns;
+            let r5 = m.return_number;
 
             if x > xmin && y > ymin {
-                if r5 == "1" {
+                if r5 == 1 {
                     let xx = ((x - xmin) / block + 0.5).floor() as u64;
                     let yy = ((y - ymin) / block + 0.5).floor() as u64;
                     *firsthit.entry((xx, yy)).or_insert(0) += 1;
@@ -191,7 +187,7 @@ pub fn makevege(config: &Config, tmpfolder: &Path) -> Result<(), Box<dyn Error>>
                 let yy = (((y - ymin) / block / (step as f64)).floor() + 0.5).floor() as u64;
                 let hh = h - thelele;
                 if hh <= 1.2 {
-                    if r3 == "2" {
+                    if r3 == 2 {
                         *ugg.entry((xx, yy)).or_insert(0.0) += 1.0;
                     } else if hh > 0.25 {
                         *ug.entry((xx, yy)).or_insert(0) += 1;
@@ -205,8 +201,8 @@ pub fn makevege(config: &Config, tmpfolder: &Path) -> Result<(), Box<dyn Error>>
                 let xx = ((x - xmin) / block + 0.5).floor() as u64;
                 let yy = ((y - ymin) / block + 0.5).floor() as u64;
                 let yyy = ((y - ymin) / block).floor() as u64; // necessary due to bug in perl version
-                if r3 == "2" || greenground >= hh {
-                    if r4 == "1" && r5 == "1" {
+                if r3 == 2 || greenground >= hh {
+                    if r4 == 1 && r5 == 1 {
                         *ghit.entry((xx, yyy)).or_insert(0) += firstandlastreturnasground;
                     } else {
                         *ghit.entry((xx, yyy)).or_insert(0) += 1;

--- a/src/vegetation.rs
+++ b/src/vegetation.rs
@@ -102,6 +102,7 @@ pub fn makevege(config: &Config, tmpfolder: &Path) -> Result<(), Box<dyn Error>>
             let x = p.x;
             let y = p.y;
             let h = p.z;
+            let m = m.expect("metadata missing");
             let r3 = m.classification;
             let r4 = m.number_of_returns;
             let r5 = m.return_number;
@@ -159,6 +160,7 @@ pub fn makevege(config: &Config, tmpfolder: &Path) -> Result<(), Box<dyn Error>>
             let x = p.x;
             let y = p.y;
             let h = p.z - zoffset;
+            let m = m.expect("metadata missing");
             let r3 = m.classification;
             let r4 = m.number_of_returns;
             let r5 = m.return_number;

--- a/src/vegetation.rs
+++ b/src/vegetation.rs
@@ -9,7 +9,7 @@ use std::f32::consts::SQRT_2;
 use std::path::Path;
 
 use crate::config::{Config, Zone};
-use crate::util::{read_lines, read_xyztemp_input_file};
+use crate::util::{read_lines, read_xyz_file};
 
 pub fn makevege(config: &Config, tmpfolder: &Path) -> Result<(), Box<dyn Error>> {
     info!("Generating vegetation...");
@@ -43,7 +43,7 @@ pub fn makevege(config: &Config, tmpfolder: &Path) -> Result<(), Box<dyn Error>>
     let mut xyz: HashMap<(u64, u64), f64> = HashMap::default();
     let mut top: HashMap<(u64, u64), f64> = HashMap::default();
 
-    read_xyztemp_input_file(xyz_file_in, config, |p, _| {
+    read_xyz_file(&xyz_file_in, config, |p, _| {
         let x = p.x;
         let y = p.y;
         let h = p.z;
@@ -95,7 +95,7 @@ pub fn makevege(config: &Config, tmpfolder: &Path) -> Result<(), Box<dyn Error>>
     let mut noyhit: HashMap<(u64, u64), u64> = HashMap::default();
 
     let mut i = 0;
-    read_xyztemp_input_file(&xyz_file_in, config, |p, m| {
+    read_xyz_file(&xyz_file_in, config, |p, m| {
         if vegethin == 0 || ((i + 1) as u32) % vegethin == 0 {
             let x = p.x;
             let y = p.y;
@@ -153,7 +153,7 @@ pub fn makevege(config: &Config, tmpfolder: &Path) -> Result<(), Box<dyn Error>>
     let step: f32 = 6.0;
 
     let mut i = 0;
-    read_xyztemp_input_file(&xyz_file_in, config, |p, m| {
+    read_xyz_file(&xyz_file_in, config, |p, m| {
         if vegethin == 0 || ((i + 1) as u32) % vegethin == 0 {
             let x = p.x;
             let y = p.y;
@@ -446,7 +446,7 @@ pub fn makevege(config: &Config, tmpfolder: &Path) -> Result<(), Box<dyn Error>>
     let buildings = config.buildings;
     let water = config.water;
     if buildings > 0 || water > 0 {
-        read_xyztemp_input_file(xyz_file_in, config, |p, m| {
+        read_xyz_file(&xyz_file_in, config, |p, m| {
             let x = p.x;
             let y = p.y;
             let c = m.expect("metadata missing").classification as u64;
@@ -470,7 +470,7 @@ pub fn makevege(config: &Config, tmpfolder: &Path) -> Result<(), Box<dyn Error>>
     }
 
     let xyz_file_in = tmpfolder.join("xyz2.xyz");
-    read_xyztemp_input_file(&xyz_file_in, config, |p, _| {
+    read_xyz_file(&xyz_file_in, config, |p, _| {
         let x = p.x;
         let y = p.y;
         let hh = p.z;

--- a/src/vegetation.rs
+++ b/src/vegetation.rs
@@ -9,7 +9,7 @@ use std::f32::consts::SQRT_2;
 use std::path::Path;
 
 use crate::config::{Config, Zone};
-use crate::util::{read_lines, read_lines_no_alloc, read_xyztemp_input_file};
+use crate::util::{read_lines, read_xyztemp_input_file};
 
 pub fn makevege(config: &Config, tmpfolder: &Path) -> Result<(), Box<dyn Error>> {
     info!("Generating vegetation...");
@@ -43,12 +43,10 @@ pub fn makevege(config: &Config, tmpfolder: &Path) -> Result<(), Box<dyn Error>>
     let mut xyz: HashMap<(u64, u64), f64> = HashMap::default();
     let mut top: HashMap<(u64, u64), f64> = HashMap::default();
 
-    read_lines_no_alloc(xyz_file_in, |line| {
-        let mut parts = line.trim().split(' ');
-
-        let x = parts.next().unwrap().parse::<f64>().unwrap();
-        let y = parts.next().unwrap().parse::<f64>().unwrap();
-        let h = parts.next().unwrap().parse::<f64>().unwrap();
+    read_xyztemp_input_file(xyz_file_in, config, |p, _| {
+        let x = p.x;
+        let y = p.y;
+        let h = p.z;
 
         let xx = ((x - xstart) / size).floor() as u64;
         let yy = ((y - ystart) / size).floor() as u64;
@@ -448,12 +446,10 @@ pub fn makevege(config: &Config, tmpfolder: &Path) -> Result<(), Box<dyn Error>>
     let buildings = config.buildings;
     let water = config.water;
     if buildings > 0 || water > 0 {
-        read_lines_no_alloc(xyz_file_in, |line| {
-            let mut parts = line.split(' ');
-            let x: f64 = parts.next().unwrap().parse::<f64>().unwrap();
-            let y: f64 = parts.next().unwrap().parse::<f64>().unwrap();
-            parts.next();
-            let c: u64 = parts.next().unwrap().parse::<u64>().unwrap();
+        read_xyztemp_input_file(xyz_file_in, config, |p, m| {
+            let x = p.x;
+            let y = p.y;
+            let c = m.expect("metadata missing").classification as u64;
 
             if c == buildings {
                 draw_filled_rect_mut(
@@ -474,11 +470,10 @@ pub fn makevege(config: &Config, tmpfolder: &Path) -> Result<(), Box<dyn Error>>
     }
 
     let xyz_file_in = tmpfolder.join("xyz2.xyz");
-    read_lines_no_alloc(xyz_file_in, |line| {
-        let mut parts = line.split(' ');
-        let x: f64 = parts.next().unwrap().parse::<f64>().unwrap();
-        let y: f64 = parts.next().unwrap().parse::<f64>().unwrap();
-        let hh: f64 = parts.next().unwrap().parse::<f64>().unwrap();
+    read_xyztemp_input_file(&xyz_file_in, config, |p, _| {
+        let x = p.x;
+        let y = p.y;
+        let hh = p.z;
 
         if hh < config.waterele {
             draw_filled_rect_mut(


### PR DESCRIPTION
- [ ] use RwLock instead of Mutex,or DashMap? (Is it worth the extra performance?)
- [ ] can we synchronize so only one thread will read each file? But this will never be the case since each thread accesses exclusively different laz files
- [ ] Implement work stealing instead of the "check if the file is there" paradigm? (Can also be done separate from the memory caching)
- [ ] we need a way to evict caches related to a certain Laz file once the processing is done (since temporary files will just be overwritten when a thread  processes other input files). A simple `clear` command at the end of each processing? 
- [ ] Actually we do not need a global hashmap / Mutex / RwLock since only one thread is processing each file serially anyways. Why not simply pass the object around instead? And then just drop it once processing is done and all allocated resources are automagically released as well 💯 Also means we can configure the behavior to not incur any overhead when doing only single processing steps (eg. without having to read the entire file contents in at once first, we can just do serial processing like before this change)
- [ ] instead of passing the temp path everywhere we can pass this object which internally handles the correct temp folder, creates paths etc. It can even return objects that have functions for reading. Like `.xyc_readonly("filename.xyz")` or `xyz_metadata_readonly("")` that will additionally include the metadata if needed. Or just one that reads from the files. The objects can have `.for_each_record(_)` function (similar to current line by line reading) or return something that implements `Iterator` (which does indeed make a lot of sense!)