### PR TITLE
reduce number of image writes and reads

### DIFF
--- a/src/blocks.rs
+++ b/src/blocks.rs
@@ -1,4 +1,4 @@
-use image::{Rgb, RgbImage, Rgba, RgbaImage};
+use image::{DynamicImage, Rgb, RgbImage, Rgba, RgbaImage};
 use imageproc::drawing::draw_filled_rect_mut;
 use imageproc::filter::median_filter;
 use imageproc::rect::Rect;
@@ -101,16 +101,14 @@ pub fn blocks(tmpfolder: &Path) -> Result<(), Box<dyn Error>> {
     })
     .expect("error reading xyz file");
 
-    let filter_size = 2;
-    img.save(tmpfolder.join("blocks.png"))
-        .expect("error saving png");
     img2.save(tmpfolder.join("blocks2.png"))
         .expect("error saving png");
-    let mut img = image::open(tmpfolder.join("blocks.png")).expect("Opening image failed");
-    let img2 = image::open(tmpfolder.join("blocks2.png")).expect("Opening image failed");
 
-    image::imageops::overlay(&mut img, &img2, 0, 0);
+    let mut img = DynamicImage::ImageRgb8(img);
 
+    image::imageops::overlay(&mut img, &DynamicImage::ImageRgba8(img2), 0, 0);
+
+    let filter_size = 2;
     img = image::DynamicImage::ImageRgb8(median_filter(&img.to_rgb8(), filter_size, filter_size));
 
     img.save(tmpfolder.join("blocks.png"))

--- a/src/vegetation.rs
+++ b/src/vegetation.rs
@@ -374,23 +374,16 @@ pub fn makevege(config: &Config, tmpfolder: &Path) -> Result<(), Box<dyn Error>>
     let med: u32 = config.med;
     let med2 = config.med2;
 
-    let mut imggr1b = RgbImage::from_pixel(img_width, img_height, Rgb([255, 255, 255]));
-    let mut imgye2b = RgbaImage::from_pixel(img_width, img_height, Rgba([255, 255, 255, 0]));
     if med > 0 {
-        imggr1b = median_filter(&imggr1, med / 2, med / 2);
-        if proceed_yellows {
-            imgye2b = median_filter(&imgye2, med / 2, med / 2);
-        }
-    }
-    if med2 > 0 {
-        imggr1 = median_filter(&imggr1b, med2 / 2, med2 / 2);
+        imggr1 = median_filter(&imggr1, med / 2, med / 2);
         if proceed_yellows {
             imgye2 = median_filter(&imgye2, med / 2, med / 2);
         }
-    } else {
-        imggr1 = imggr1b;
+    }
+    if med2 > 0 {
+        imggr1 = median_filter(&imggr1, med2 / 2, med2 / 2);
         if proceed_yellows {
-            imgye2 = imgye2b;
+            imgye2 = median_filter(&imgye2, med / 2, med / 2);
         }
     }
 

--- a/src/vegetation.rs
+++ b/src/vegetation.rs
@@ -266,22 +266,14 @@ pub fn makevege(config: &Config, tmpfolder: &Path) -> Result<(), Box<dyn Error>>
         (h * block * 600.0 / 254.0 / scalefactor) as u32,
         Luma([0x00]),
     );
-    let mut imggr1 =
-        RgbImage::from_pixel((w * block) as u32, (h * block) as u32, Rgb([255, 255, 255]));
-    let mut imggr1b =
-        RgbImage::from_pixel((w * block) as u32, (h * block) as u32, Rgb([255, 255, 255]));
-    let mut imgye2 = RgbaImage::from_pixel(
-        (w * block) as u32,
-        (h * block) as u32,
-        Rgba([255, 255, 255, 0]),
-    );
-    let mut imgye2b = RgbaImage::from_pixel(
-        (w * block) as u32,
-        (h * block) as u32,
-        Rgba([255, 255, 255, 0]),
-    );
-    let mut imgwater =
-        RgbImage::from_pixel((w * block) as u32, (h * block) as u32, Rgb([255, 255, 255]));
+
+    let img_width = (w * block) as u32;
+    let img_height = (h * block) as u32;
+
+    let mut imggr1 = RgbImage::from_pixel(img_width, img_height, Rgb([255, 255, 255]));
+    let mut imggr1b = RgbImage::from_pixel(img_width, img_height, Rgb([255, 255, 255]));
+    let mut imgye2 = RgbaImage::from_pixel(img_width, img_height, Rgba([255, 255, 255, 0]));
+    let mut imgye2b = RgbaImage::from_pixel(img_width, img_height, Rgba([255, 255, 255, 0]));
 
     let greens = (0..greenshades.len())
         .map(|i| {
@@ -472,6 +464,7 @@ pub fn makevege(config: &Config, tmpfolder: &Path) -> Result<(), Box<dyn Error>>
             .expect("could not save output png");
     }
 
+    let mut imgwater = RgbImage::from_pixel(img_width, img_height, Rgb([255, 255, 255]));
     let black = Rgb([0, 0, 0]);
     let blue = Rgb([29, 190, 255]);
     let buildings = config.buildings;
@@ -522,6 +515,8 @@ pub fn makevege(config: &Config, tmpfolder: &Path) -> Result<(), Box<dyn Error>>
     imgwater
         .save(tmpfolder.join("blueblack.png"))
         .expect("could not save output png");
+
+    drop(imgwater); // explicitly drop imgwater to free memory
 
     let underg = Rgba([64, 121, 0, 255]);
     let tmpfactor = (600.0 / 254.0 / scalefactor) as f32;

--- a/src/vegetation.rs
+++ b/src/vegetation.rs
@@ -256,24 +256,11 @@ pub fn makevege(config: &Config, tmpfolder: &Path) -> Result<(), Box<dyn Error>>
 
     let scalefactor = config.scalefactor;
 
-    let mut imgug = RgbaImage::from_pixel(
-        (w * block * 600.0 / 254.0 / scalefactor) as u32,
-        (h * block * 600.0 / 254.0 / scalefactor) as u32,
-        Rgba([255, 255, 255, 0]),
-    );
-    let mut img_ug_bit = GrayImage::from_pixel(
-        (w * block * 600.0 / 254.0 / scalefactor) as u32,
-        (h * block * 600.0 / 254.0 / scalefactor) as u32,
-        Luma([0x00]),
-    );
-
     let img_width = (w * block) as u32;
     let img_height = (h * block) as u32;
 
     let mut imggr1 = RgbImage::from_pixel(img_width, img_height, Rgb([255, 255, 255]));
-    let mut imggr1b = RgbImage::from_pixel(img_width, img_height, Rgb([255, 255, 255]));
     let mut imgye2 = RgbaImage::from_pixel(img_width, img_height, Rgba([255, 255, 255, 0]));
-    let mut imgye2b = RgbaImage::from_pixel(img_width, img_height, Rgba([255, 255, 255, 0]));
 
     let greens = (0..greenshades.len())
         .map(|i| {
@@ -389,6 +376,8 @@ pub fn makevege(config: &Config, tmpfolder: &Path) -> Result<(), Box<dyn Error>>
     let med: u32 = config.med;
     let med2 = config.med2;
 
+    let mut imggr1b = RgbImage::from_pixel(img_width, img_height, Rgb([255, 255, 255]));
+    let mut imgye2b = RgbaImage::from_pixel(img_width, img_height, Rgba([255, 255, 255, 0]));
     if med > 0 {
         imggr1b = median_filter(&imggr1, med / 2, med / 2);
         if proceed_yellows {
@@ -419,6 +408,10 @@ pub fn makevege(config: &Config, tmpfolder: &Path) -> Result<(), Box<dyn Error>>
     image::imageops::overlay(&mut img, &img2, 0, 0);
     img.save(tmpfolder.join("vegetation.png"))
         .expect("could not save output png");
+
+    // drop imggr1, imggr1b, imgye2, imgye2b to free memory
+    drop(img);
+    drop(img2);
 
     if vege_bitmode {
         let g_img = image::open(tmpfolder.join("greens.png")).expect("Opening image failed");
@@ -527,6 +520,16 @@ pub fn makevege(config: &Config, tmpfolder: &Path) -> Result<(), Box<dyn Error>>
     let hh = hf32 * bf32;
     let mut x = 0.0_f32;
 
+    let mut imgug = RgbaImage::from_pixel(
+        (w * block * 600.0 / 254.0 / scalefactor) as u32,
+        (h * block * 600.0 / 254.0 / scalefactor) as u32,
+        Rgba([255, 255, 255, 0]),
+    );
+    let mut img_ug_bit = GrayImage::from_pixel(
+        (w * block * 600.0 / 254.0 / scalefactor) as u32,
+        (h * block * 600.0 / 254.0 / scalefactor) as u32,
+        Luma([0x00]),
+    );
     loop {
         if x >= ww {
             break;

--- a/src/vegetation.rs
+++ b/src/vegetation.rs
@@ -143,6 +143,7 @@ pub fn makevege(config: &Config, tmpfolder: &Path) -> Result<(), Box<dyn Error>>
         i += 1;
     })
     .expect("Can not read file");
+    // rebind the variables to be non-mut for the rest of the function
     let (yhit, noyhit) = (yhit, noyhit);
 
     let mut firsthit: HashMap<(u64, u64), u64> = HashMap::default();
@@ -243,6 +244,7 @@ pub fn makevege(config: &Config, tmpfolder: &Path) -> Result<(), Box<dyn Error>>
         i += 1;
     })
     .expect("Can not read file");
+    // rebind the variables to be non-mut for the rest of the function
     let (firsthit, ugg, ug, ghit, greenhit, highit) = (firsthit, ugg, ug, ghit, greenhit, highit);
 
     let w = (xmax - xmin).floor() / block;


### PR DESCRIPTION
Just a small improvement to the memory usage during vegetation generation. Instead of allocating all image buffers at the start and keeping them alive until the end, we allocate them when needed and `drop` them when we are done :rocket: This reduces the maximum amount of memory needed during this phase. Also removed a few allocations that were not necessary, simplified the logic a bit (mostly for easier readability), and changed some places where the image files were written and then immediately read again to only write once. Should potentially give some memory and performance improvements :100: 

Btw, I noticed that the `vegethin` parameter is not defined in the default configuration file.