### PR TITLE
Feature/heightmap

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,6 +74,7 @@ Previously, Karttapullautin used regular text-based `.xyz` files to store the te
 ```
 ./pullauta internal2xyz temp/xyztemp.xyz.bin temp/xyztemp.xyz
 ```
+> Note: this also works for the binary `.hmap` files.
 
 ### Fine tuning the output
 

--- a/src/blocks.rs
+++ b/src/blocks.rs
@@ -46,10 +46,9 @@ pub fn blocks(tmpfolder: &Path) -> Result<(), Box<dyn Error>> {
     let mut reader = XyzInternalReader::open(&xyz_file_in).unwrap();
     while let Some(r) = reader.next().unwrap() {
         let (x, y, h) = (r.x, r.y, r.z);
-        let m = r.meta.unwrap();
-        let r3 = m.classification;
-        let r4 = m.number_of_returns;
-        let r5 = m.return_number;
+        let r3 = r.classification;
+        let r4 = r.number_of_returns;
+        let r5 = r.return_number;
 
         let xx = ((x - xstartxyz) / size).floor() as u64;
         let yy = ((y - ystartxyz) / size).floor() as u64;

--- a/src/cliffs.rs
+++ b/src/cliffs.rs
@@ -48,8 +48,8 @@ pub fn makecliffs(config: &Config, tmpfolder: &Path) -> Result<(), Box<dyn Error
     let ystart = hmap.yoffset;
     let size = hmap.scale;
 
-    let sxmax = hmap.grid.width();
-    let symax = hmap.grid.height();
+    let sxmax = hmap.grid.width() - 1;
+    let symax = hmap.grid.height() - 1;
 
     let mut steepness = Vec2D::new(sxmax + 1, symax + 1, f64::NAN);
 

--- a/src/cliffs.rs
+++ b/src/cliffs.rs
@@ -278,7 +278,7 @@ pub fn makecliffs(config: &Config, tmpfolder: &Path) -> Result<(), Box<dyn Error
     let heightmap_in = tmpfolder.join("xyz2.xyz.bin.hmap");
     let mut reader = BufReader::new(File::open(heightmap_in)?);
     let hmap = HeightMap::from_bytes(&mut reader)?;
-    for (x, y, h) in hmap.iter_values() {
+    for (x, y, h) in hmap.iter() {
         if cliff_thin == 1.0 || rng.sample(randdist) {
             list_alt[(
                 ((x - xmin).floor() / 3.0) as usize,

--- a/src/cliffs.rs
+++ b/src/cliffs.rs
@@ -48,8 +48,6 @@ pub fn makecliffs(config: &Config, tmpfolder: &Path) -> Result<(), Box<dyn Error
     let ystart = hmap.yoffset;
     let size = hmap.scale;
 
-    let xyz = hmap.grid.clone();
-
     let sxmax = hmap.grid.width();
     let symax = hmap.grid.height();
 
@@ -61,7 +59,7 @@ pub fn makecliffs(config: &Config, tmpfolder: &Path) -> Result<(), Box<dyn Error
             let mut high: f64 = f64::MIN;
             for ii in i - 3..i + 4 {
                 for jj in j - 3..j + 4 {
-                    let value = xyz[(ii, jj)];
+                    let value = hmap.grid[(ii, jj)];
 
                     if value < low {
                         low = value;
@@ -277,7 +275,6 @@ pub fn makecliffs(config: &Config, tmpfolder: &Path) -> Result<(), Box<dyn Error
         Vec::<(f64, f64, f64)>::new(),
     );
 
-    // TODO:
     let heightmap_in = tmpfolder.join("xyz2.xyz.bin.hmap");
     let mut reader = BufReader::new(File::open(heightmap_in)?);
     let hmap = HeightMap::from_bytes(&mut reader)?;

--- a/src/cliffs.rs
+++ b/src/cliffs.rs
@@ -97,7 +97,7 @@ pub fn makecliffs(config: &Config, tmpfolder: &Path) -> Result<(), Box<dyn Error
     while let Some(r) = reader.next()? {
         if cliff_thin == 1.0 || rng.sample(randdist) {
             let (x, y, h) = (r.x, r.y, r.z);
-            let r3 = r.meta.unwrap().classification;
+            let r3 = r.classification;
 
             if r3 == 2 {
                 list_alt[(

--- a/src/cliffs.rs
+++ b/src/cliffs.rs
@@ -34,7 +34,7 @@ pub fn makecliffs(config: &Config, tmpfolder: &Path) -> Result<(), Box<dyn Error
         no_small_ciffs -= flat_place;
     }
 
-    let heightmap_in = tmpfolder.join("xyz2.xyz.bin.hmap");
+    let heightmap_in = tmpfolder.join("xyz2.hmap");
     let mut reader = BufReader::new(File::open(heightmap_in)?);
     let hmap = HeightMap::from_bytes(&mut reader)?;
 
@@ -275,7 +275,7 @@ pub fn makecliffs(config: &Config, tmpfolder: &Path) -> Result<(), Box<dyn Error
         Vec::<(f64, f64, f64)>::new(),
     );
 
-    let heightmap_in = tmpfolder.join("xyz2.xyz.bin.hmap");
+    let heightmap_in = tmpfolder.join("xyz2.hmap");
     let mut reader = BufReader::new(File::open(heightmap_in)?);
     let hmap = HeightMap::from_bytes(&mut reader)?;
     for (x, y, h) in hmap.iter() {

--- a/src/contours.rs
+++ b/src/contours.rs
@@ -266,7 +266,7 @@ pub fn xyz2contours(
             xoffset: xmin,
             yoffset: ymin,
             scale: 2.0 * scalefactor,
-            data: avg_alt.clone(),
+            grid: avg_alt.clone(),
         };
 
         let hmap_file = tmpfolder.join(format!("{xyzfileout}.hmap"));

--- a/src/contours.rs
+++ b/src/contours.rs
@@ -37,9 +37,7 @@ pub fn xyz2heightmap(
     let xyz_file_in = tmpfolder.join(xyzfilein);
     let mut reader = XyzInternalReader::new(BufReader::new(std::fs::File::open(&xyz_file_in)?))?;
     while let Some(r) = reader.next()? {
-        if r.meta
-            .is_some_and(|m| m.classification == 2 || m.classification == water_class)
-        {
+        if r.classification == 2 || r.classification == water_class {
             let x: f64 = r.x;
             let y: f64 = r.y;
             let h: f64 = r.z;
@@ -82,9 +80,7 @@ pub fn xyz2heightmap(
 
     let mut reader = XyzInternalReader::new(BufReader::new(std::fs::File::open(&xyz_file_in)?))?;
     while let Some(r) = reader.next()? {
-        if r.meta
-            .is_some_and(|m| m.classification == 2 || m.classification == water_class)
-        {
+        if r.classification == 2 || r.classification == water_class {
             let x: f64 = r.x;
             let y: f64 = r.y;
             let h: f64 = r.z;

--- a/src/contours.rs
+++ b/src/contours.rs
@@ -208,7 +208,7 @@ pub fn xyz2heightmap(
     xmin += 1.0;
     ymin += 1.0;
 
-    for (_, _, ele) in avg_alt.iter_idx_mut() {
+    for (_, _, ele) in avg_alt.iter_mut() {
         let temp: f64 = (*ele / cinterval + 0.5).floor() * cinterval;
         if (*ele - temp).abs() < 0.02 {
             if *ele - temp < 0.0 {
@@ -258,7 +258,7 @@ pub fn heightmap2contours(
     let size = heightmap.scale;
 
     // this "correction" is needed here since the cinterval of the heightmap might be different from the one used for the contours
-    for (_, _, ele) in avg_alt.iter_idx_mut() {
+    for (_, _, ele) in avg_alt.iter_mut() {
         let temp: f64 = (*ele / cinterval + 0.5).floor() * cinterval;
         if (*ele - temp).abs() < 0.02 {
             if *ele - temp < 0.0 {
@@ -272,7 +272,7 @@ pub fn heightmap2contours(
     // compute hmin and hmax
     let mut hmin: f64 = f64::MAX;
     let mut hmax: f64 = f64::MIN;
-    for (_, _, h) in avg_alt.iter_idx() {
+    for (_, _, h) in avg_alt.iter() {
         if h < hmin {
             hmin = h;
         }

--- a/src/io/bytes.rs
+++ b/src/io/bytes.rs
@@ -3,6 +3,7 @@ pub trait FromToBytes: Sized {
     /// Read a value from a byte stream.
     fn from_bytes<R: std::io::Read>(reader: &mut R) -> std::io::Result<Self>;
 
+    /// Write a value to a byte stream.
     fn to_bytes<W: std::io::Write>(&self, writer: &mut W) -> std::io::Result<()>;
 }
 
@@ -37,5 +38,31 @@ impl FromToBytes for u64 {
     }
     fn to_bytes<W: std::io::Write>(&self, writer: &mut W) -> std::io::Result<()> {
         writer.write_all(&self.to_ne_bytes())
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+
+    #[test]
+    fn test_u64() {
+        let mut buff = Vec::new();
+        42u64.to_bytes(&mut buff).unwrap();
+        assert_eq!(u64::from_bytes(&mut buff.as_slice()).unwrap(), 42);
+    }
+
+    #[test]
+    fn test_f64() {
+        let mut buff = Vec::new();
+        42.0f64.to_bytes(&mut buff).unwrap();
+        assert_eq!(f64::from_bytes(&mut buff.as_slice()).unwrap(), 42.0);
+    }
+
+    #[test]
+    fn test_usize() {
+        let mut buff = Vec::new();
+        42usize.to_bytes(&mut buff).unwrap();
+        assert_eq!(usize::from_bytes(&mut buff.as_slice()).unwrap(), 42);
     }
 }

--- a/src/io/bytes.rs
+++ b/src/io/bytes.rs
@@ -28,3 +28,14 @@ impl FromToBytes for usize {
         writer.write_all(&self.to_ne_bytes())
     }
 }
+
+impl FromToBytes for u64 {
+    fn from_bytes<R: std::io::Read>(reader: &mut R) -> std::io::Result<Self> {
+        let mut buff = [0; 8];
+        reader.read_exact(&mut buff)?;
+        Ok(u64::from_ne_bytes(buff))
+    }
+    fn to_bytes<W: std::io::Write>(&self, writer: &mut W) -> std::io::Result<()> {
+        writer.write_all(&self.to_ne_bytes())
+    }
+}

--- a/src/io/bytes.rs
+++ b/src/io/bytes.rs
@@ -1,0 +1,30 @@
+/// Trait defining how to read and write a value from a byte stream.
+pub trait FromToBytes: Sized {
+    /// Read a value from a byte stream.
+    fn from_bytes<R: std::io::Read>(reader: &mut R) -> std::io::Result<Self>;
+
+    fn to_bytes<W: std::io::Write>(&self, writer: &mut W) -> std::io::Result<()>;
+}
+
+impl FromToBytes for f64 {
+    fn from_bytes<R: std::io::Read>(reader: &mut R) -> std::io::Result<Self> {
+        let mut buff = [0; 8];
+        reader.read_exact(&mut buff)?;
+        Ok(f64::from_ne_bytes(buff))
+    }
+
+    fn to_bytes<W: std::io::Write>(&self, writer: &mut W) -> std::io::Result<()> {
+        writer.write_all(&self.to_ne_bytes())
+    }
+}
+
+impl FromToBytes for usize {
+    fn from_bytes<R: std::io::Read>(reader: &mut R) -> std::io::Result<Self> {
+        let mut buff = [0; 8];
+        reader.read_exact(&mut buff)?;
+        Ok(usize::from_ne_bytes(buff))
+    }
+    fn to_bytes<W: std::io::Write>(&self, writer: &mut W) -> std::io::Result<()> {
+        writer.write_all(&self.to_ne_bytes())
+    }
+}

--- a/src/io/heightmap.rs
+++ b/src/io/heightmap.rs
@@ -44,6 +44,22 @@ impl HeightMap {
     }
 }
 
+impl HeightMap {
+    /// Helper for easily reading a HeightMap from a file
+    pub fn from_file<P: AsRef<std::path::Path>>(path: P) -> std::io::Result<Self> {
+        let file = std::fs::File::open(path)?;
+        let mut reader = std::io::BufReader::new(file);
+        HeightMap::from_bytes(&mut reader)
+    }
+
+    /// Helper for easily writing a HeightMap to a file
+    pub fn to_file<P: AsRef<std::path::Path>>(&self, path: P) -> std::io::Result<()> {
+        let file = std::fs::File::create(path)?;
+        let mut writer = std::io::BufWriter::new(file);
+        self.to_bytes(&mut writer)
+    }
+}
+
 impl FromToBytes for HeightMap {
     fn from_bytes<R: std::io::Read>(reader: &mut R) -> std::io::Result<Self> {
         let xoffset = f64::from_bytes(reader)?;

--- a/src/io/heightmap.rs
+++ b/src/io/heightmap.rs
@@ -33,8 +33,8 @@ impl HeightMap {
         self.yoffset + self.scale * (self.grid.height() - 1) as f64
     }
 
-    pub fn iter_values(&self) -> impl Iterator<Item = (f64, f64, f64)> + '_ {
-        self.grid.iter_idx().map(|(x, y, v)| {
+    pub fn iter(&self) -> impl Iterator<Item = (f64, f64, f64)> + '_ {
+        self.grid.iter().map(|(x, y, v)| {
             (
                 self.xoffset + self.scale * x as f64,
                 self.yoffset + self.scale * y as f64,

--- a/src/io/heightmap.rs
+++ b/src/io/heightmap.rs
@@ -23,11 +23,14 @@ impl HeightMap {
     pub fn miny(&self) -> f64 {
         self.yoffset
     }
+    /// Get the maximum x-coordinate of the heightmap
     pub fn maxx(&self) -> f64 {
-        self.xoffset + self.scale * self.grid.width() as f64
+        self.xoffset + self.scale * (self.grid.width() - 1) as f64
     }
+
+    /// Get the maximum y-coordinate of the heightmap
     pub fn maxy(&self) -> f64 {
-        self.yoffset + self.scale * self.grid.height() as f64
+        self.yoffset + self.scale * (self.grid.height() - 1) as f64
     }
 
     pub fn iter_values(&self) -> impl Iterator<Item = (f64, f64, f64)> + '_ {

--- a/src/io/heightmap.rs
+++ b/src/io/heightmap.rs
@@ -1,0 +1,42 @@
+use crate::vec2d::Vec2D;
+
+use super::bytes::FromToBytes;
+
+/// Simple container of a rectangular heightmap
+pub struct HeightMap {
+    /// Offset to add to the x-component to get the cell coordinate.
+    pub xoffset: f64,
+    /// Offset to add to the y-component to get the cell coordinate.
+    pub yoffset: f64,
+    /// Scale to apply to get the cell coordinate.
+    pub scale: f64,
+
+    /// The actual grid data
+    pub data: Vec2D<f64>,
+}
+
+impl HeightMap {}
+
+impl FromToBytes for HeightMap {
+    fn from_bytes<R: std::io::Read>(reader: &mut R) -> std::io::Result<Self> {
+        let xoffset = f64::from_bytes(reader)?;
+        let yoffset = f64::from_bytes(reader)?;
+        let scale = f64::from_bytes(reader)?;
+
+        let data = Vec2D::from_bytes(reader)?;
+
+        Ok(HeightMap {
+            xoffset,
+            yoffset,
+            scale,
+            data,
+        })
+    }
+
+    fn to_bytes<W: std::io::Write>(&self, writer: &mut W) -> std::io::Result<()> {
+        self.xoffset.to_bytes(writer)?;
+        self.yoffset.to_bytes(writer)?;
+        self.scale.to_bytes(writer)?;
+        self.data.to_bytes(writer)
+    }
+}

--- a/src/io/heightmap.rs
+++ b/src/io/heightmap.rs
@@ -3,6 +3,7 @@ use crate::vec2d::Vec2D;
 use super::bytes::FromToBytes;
 
 /// Simple container of a rectangular heightmap
+#[derive(Debug, Clone)]
 pub struct HeightMap {
     /// Offset to add to the x-component to get the cell coordinate.
     pub xoffset: f64,
@@ -12,10 +13,33 @@ pub struct HeightMap {
     pub scale: f64,
 
     /// The actual grid data
-    pub data: Vec2D<f64>,
+    pub grid: Vec2D<f64>,
 }
 
-impl HeightMap {}
+impl HeightMap {
+    pub fn minx(&self) -> f64 {
+        self.xoffset
+    }
+    pub fn miny(&self) -> f64 {
+        self.yoffset
+    }
+    pub fn maxx(&self) -> f64 {
+        self.xoffset + self.scale * self.grid.width() as f64
+    }
+    pub fn maxy(&self) -> f64 {
+        self.yoffset + self.scale * self.grid.height() as f64
+    }
+
+    pub fn iter_values(&self) -> impl Iterator<Item = (f64, f64, f64)> + '_ {
+        self.grid.iter_idx().map(|(x, y, v)| {
+            (
+                self.xoffset + self.scale * x as f64,
+                self.yoffset + self.scale * y as f64,
+                v,
+            )
+        })
+    }
+}
 
 impl FromToBytes for HeightMap {
     fn from_bytes<R: std::io::Read>(reader: &mut R) -> std::io::Result<Self> {
@@ -29,7 +53,7 @@ impl FromToBytes for HeightMap {
             xoffset,
             yoffset,
             scale,
-            data,
+            grid: data,
         })
     }
 
@@ -37,6 +61,6 @@ impl FromToBytes for HeightMap {
         self.xoffset.to_bytes(writer)?;
         self.yoffset.to_bytes(writer)?;
         self.scale.to_bytes(writer)?;
-        self.data.to_bytes(writer)
+        self.grid.to_bytes(writer)
     }
 }

--- a/src/io/mod.rs
+++ b/src/io/mod.rs
@@ -4,6 +4,8 @@ use std::{
     path::Path,
 };
 
+pub mod bytes;
+pub mod heightmap;
 pub mod xyz;
 
 /// Helper function to convert an internal xyz file to a regular xyz file.

--- a/src/io/mod.rs
+++ b/src/io/mod.rs
@@ -4,26 +4,39 @@ use std::{
     path::Path,
 };
 
+use heightmap::HeightMap;
+
 pub mod bytes;
 pub mod heightmap;
 pub mod xyz;
 
 /// Helper function to convert an internal xyz file to a regular xyz file.
 pub fn internal2xyz(input: &str, output: &str) -> std::io::Result<()> {
-    let mut reader = xyz::XyzInternalReader::open(Path::new(input))?;
-    let mut writer = BufWriter::new(File::create(output)?);
+    if input.ends_with(".xyz.bin") {
+        let mut reader = xyz::XyzInternalReader::open(Path::new(input))?;
+        let mut writer = BufWriter::new(File::create(output)?);
 
-    while let Some(record) = reader.next()? {
-        writeln!(
-            writer,
-            "{} {} {} {} {} {}",
-            record.x,
-            record.y,
-            record.z,
-            record.classification,
-            record.number_of_returns,
-            record.return_number
-        )?;
+        while let Some(record) = reader.next()? {
+            writeln!(
+                writer,
+                "{} {} {} {} {} {}",
+                record.x,
+                record.y,
+                record.z,
+                record.classification,
+                record.number_of_returns,
+                record.return_number
+            )?;
+        }
+    } else if input.ends_with(".hmap") {
+        let hmap = HeightMap::from_file(input)?;
+        let mut writer = BufWriter::new(File::create(output)?);
+
+        for (x, y, h) in hmap.iter() {
+            writeln!(writer, "{} {} {}", x, y, h)?;
+        }
+    } else {
+        panic!("Unknown internal file format: {}", input);
     }
 
     Ok(())

--- a/src/io/mod.rs
+++ b/src/io/mod.rs
@@ -14,20 +14,16 @@ pub fn internal2xyz(input: &str, output: &str) -> std::io::Result<()> {
     let mut writer = BufWriter::new(File::create(output)?);
 
     while let Some(record) = reader.next()? {
-        if let Some(meta) = record.meta {
-            writeln!(
-                writer,
-                "{} {} {} {} {} {}",
-                record.x,
-                record.y,
-                record.z,
-                meta.classification,
-                meta.number_of_returns,
-                meta.return_number
-            )?;
-        } else {
-            writeln!(writer, "{} {} {}", record.x, record.y, record.z)?;
-        }
+        writeln!(
+            writer,
+            "{} {} {} {} {} {}",
+            record.x,
+            record.y,
+            record.z,
+            record.classification,
+            record.number_of_returns,
+            record.return_number
+        )?;
     }
 
     Ok(())

--- a/src/knolls.rs
+++ b/src/knolls.rs
@@ -198,7 +198,7 @@ pub fn knolldetector(config: &Config, tmpfolder: &Path) -> Result<(), Box<dyn Er
 
     // Temporary hashmap to store the xyz values
     let mut xyz: HashMap<(u64, u64), f64> = HashMap::default();
-    for (x, y, h) in hmap.grid.iter_idx() {
+    for (x, y, h) in hmap.grid.iter() {
         xyz.insert((x as u64, y as u64), h);
     }
 
@@ -1096,7 +1096,7 @@ pub fn xyzknolls(config: &Config, tmpfolder: &Path) -> Result<(), Box<dyn Error>
         }
     }
 
-    for (_, _, h) in xyz2.grid.iter_idx_mut() {
+    for (_, _, h) in xyz2.grid.iter_mut() {
         let tmp = (*h / interval + 0.5).floor() * interval;
         if (tmp - *h).abs() < 0.02 {
             if *h - tmp < 0.0 {

--- a/src/knolls.rs
+++ b/src/knolls.rs
@@ -147,41 +147,6 @@ pub fn knolldetector(config: &Config, tmpfolder: &Path) -> Result<(), Box<dyn Er
 
     let interval = 0.3 * scalefactor;
 
-    // let xyz_file_in = tmpfolder.join("xyz_03.xyz.bin");
-    //
-    // let mut reader = XyzInternalReader::open(&xyz_file_in)?;
-    // let first = reader.next()?.expect("should have record");
-    // let second = reader.next()?.expect("should have record");
-    // let (xstart, ystart, size) = (first.x, first.y, second.y - first.y);
-
-    // let mut xmax: u64 = u64::MIN;
-    // let mut ymax: u64 = u64::MIN;
-    // let mut xmin: u64 = u64::MAX;
-    // let mut ymin: u64 = u64::MAX;
-    // let mut xyz: HashMap<(u64, u64), f64> = HashMap::default();
-    // let mut reader = XyzInternalReader::open(&xyz_file_in)?;
-    // while let Some(r) = reader.next()? {
-    //     let (x, y, h) = (r.x, r.y, r.z);
-    //
-    //     let xx = ((x - xstart) / size).floor() as u64;
-    //     let yy = ((y - ystart) / size).floor() as u64;
-    //
-    //     xyz.insert((xx, yy), h);
-    //
-    //     if xmax < xx {
-    //         xmax = xx;
-    //     }
-    //     if ymax < yy {
-    //         ymax = yy;
-    //     }
-    //     if xmin > xx {
-    //         xmin = xx;
-    //     }
-    //     if ymin > yy {
-    //         ymin = yy;
-    //     }
-    // }
-
     let heightmap_in = tmpfolder.join("xyz_03.hmap");
     let mut reader = BufReader::new(File::open(heightmap_in)?);
     let hmap = HeightMap::from_bytes(&mut reader)?;

--- a/src/knolls.rs
+++ b/src/knolls.rs
@@ -27,8 +27,8 @@ pub fn dotknolls(config: &Config, tmpfolder: &Path) -> Result<(), Box<dyn Error>
     let ystart = hmap.yoffset;
 
     // in grid coordinates
-    let xmax = hmap.grid.width() as f64;
-    let ymax = hmap.grid.height() as f64;
+    let xmax = (hmap.grid.width() - 1) as f64;
+    let ymax = (hmap.grid.height() - 1) as f64;
     let size = hmap.scale;
 
     let mut im = GrayImage::from_pixel(
@@ -194,8 +194,8 @@ pub fn knolldetector(config: &Config, tmpfolder: &Path) -> Result<(), Box<dyn Er
 
     // in grid coordinates
     let (xmin, ymin) = (0, 0);
-    let xmax = hmap.grid.width() as u64;
-    let ymax = hmap.grid.height() as u64;
+    let xmax = (hmap.grid.width() - 1) as u64;
+    let ymax = (hmap.grid.height() - 1) as u64;
 
     // Temporary hashmap to store the xyz values
     let mut xyz: HashMap<(u64, u64), f64> = HashMap::default();
@@ -914,27 +914,16 @@ pub fn xyzknolls(config: &Config, tmpfolder: &Path) -> Result<(), Box<dyn Error>
 
     let hmap = HeightMap::from_bytes(&mut reader)?;
 
-    let xmax = hmap.grid.width();
-    let ymax = hmap.grid.height();
+    let xmax = hmap.grid.width() - 1;
+    let ymax = hmap.grid.height() - 1;
     let size = hmap.scale;
     let xstart = hmap.xoffset;
     let ystart = hmap.yoffset;
 
-    // let mut xyz_new: HashMap<(u64, u64), f64> = HashMap::default();
-    // for (i, j, h) in hmap.grid.iter_idx() {
-    //     xyz_new.insert((i as u64, j as u64), h);
-    // }
-    println!(
-        "xmax: {}, ymax: {}",
-        xmax,
-        ymax,
-        // xyz_new.len(),
-    );
-
     let mut xyz2 = hmap.clone();
 
-    for i in 2..(xmax - 2) {
-        for j in 2..(ymax - 2) {
+    for i in 2..=(xmax - 2) {
+        for j in 2..=(ymax - 2) {
             let mut low = f64::MAX;
             let mut high = f64::MIN;
             let mut val = 0.0;

--- a/src/knolls.rs
+++ b/src/knolls.rs
@@ -18,32 +18,6 @@ pub fn dotknolls(config: &Config, tmpfolder: &Path) -> Result<(), Box<dyn Error>
 
     let scalefactor = config.scalefactor;
 
-    // let xyz_file_in = tmpfolder.join("xyz_knolls.xyz.bin");
-
-    // let mut reader = XyzInternalReader::open(&xyz_file_in)?;
-    // let first = reader.next()?.expect("should have record");
-    // let second = reader.next()?.expect("should have record");
-    // let (xstart, ystart, size) = (first.x, first.y, second.y - first.y);
-
-    // let mut xmax = 0.0;
-    // let mut ymax = 0.0;
-    //
-    // let mut reader = XyzInternalReader::open(&xyz_file_in)?;
-    // while let Some(r) = reader.next()? {
-    //     let (x, y) = (r.x, r.y);
-    //
-    //     let xx = ((x - xstart) / size).floor();
-    //     let yy = ((y - ystart) / size).floor();
-    //
-    //     if xmax < xx {
-    //         xmax = xx;
-    //     }
-    //
-    //     if ymax < yy {
-    //         ymax = yy;
-    //     }
-    // }
-
     let heightmap_in = tmpfolder.join("xyz_knolls.xyz.bin.hmap");
     let mut reader = BufReader::new(File::open(heightmap_in)?);
     let hmap = HeightMap::from_bytes(&mut reader)?;

--- a/src/knolls.rs
+++ b/src/knolls.rs
@@ -17,7 +17,7 @@ pub fn dotknolls(config: &Config, tmpfolder: &Path) -> Result<(), Box<dyn Error>
 
     let scalefactor = config.scalefactor;
 
-    let heightmap_in = tmpfolder.join("xyz_knolls.xyz.bin.hmap");
+    let heightmap_in = tmpfolder.join("xyz_knolls.hmap");
     let mut reader = BufReader::new(File::open(heightmap_in)?);
     let hmap = HeightMap::from_bytes(&mut reader)?;
 
@@ -182,7 +182,7 @@ pub fn knolldetector(config: &Config, tmpfolder: &Path) -> Result<(), Box<dyn Er
     //     }
     // }
 
-    let heightmap_in = tmpfolder.join("xyz_03.xyz.bin.hmap");
+    let heightmap_in = tmpfolder.join("xyz_03.hmap");
     let mut reader = BufReader::new(File::open(heightmap_in)?);
     let hmap = HeightMap::from_bytes(&mut reader)?;
 
@@ -882,7 +882,7 @@ pub fn xyzknolls(config: &Config, tmpfolder: &Path) -> Result<(), Box<dyn Error>
     let interval = contour_interval / 2.0 * scalefactor;
 
     // load the binary file
-    let heightmap_in = tmpfolder.join("xyz_03.xyz.bin.hmap");
+    let heightmap_in = tmpfolder.join("xyz_03.hmap");
     let mut reader = BufReader::new(File::open(heightmap_in)?);
 
     let hmap = HeightMap::from_bytes(&mut reader)?;
@@ -1108,7 +1108,7 @@ pub fn xyzknolls(config: &Config, tmpfolder: &Path) -> Result<(), Box<dyn Error>
     }
 
     // write the updated heightmap
-    let heightmap_out = tmpfolder.join("xyz_knolls.xyz.bin.hmap");
+    let heightmap_out = tmpfolder.join("xyz_knolls.hmap");
     let mut writer = BufWriter::new(File::create(heightmap_out)?);
     xyz2.to_bytes(&mut writer)?;
 

--- a/src/knolls.rs
+++ b/src/knolls.rs
@@ -909,31 +909,31 @@ pub fn xyzknolls(config: &Config, tmpfolder: &Path) -> Result<(), Box<dyn Error>
     let interval = contour_interval / 2.0 * scalefactor;
 
     let xyz_file_in = tmpfolder.join("xyz_03.xyz.bin");
+    //
+    // let mut reader = XyzInternalReader::open(&xyz_file_in)?;
+    // let first = reader.next()?.expect("should have record");
+    // let second = reader.next()?.expect("should have record");
+    // let (xstart, ystart, size) = (first.x, first.y, second.y - first.y);
+    //
+    // let mut xmax: u64 = 0;
+    // let mut ymax: u64 = 0;
+    // let mut xyz: HashMap<(u64, u64), f64> = HashMap::default();
+    // let mut reader = XyzInternalReader::open(&xyz_file_in).unwrap();
+    // while let Some(r) = reader.next()? {
+    //     let (x, y, h) = (r.x, r.y, r.z);
+    //
+    //     let xx = ((x - xstart) / size).floor() as u64;
+    //     let yy = ((y - ystart) / size).floor() as u64;
+    //     xyz.insert((xx, yy), h);
+    //     if xmax < xx {
+    //         xmax = xx;
+    //     }
+    //     if ymax < yy {
+    //         ymax = yy;
+    //     }
+    // }
 
-    let mut reader = XyzInternalReader::open(&xyz_file_in)?;
-    let first = reader.next()?.expect("should have record");
-    let second = reader.next()?.expect("should have record");
-    let (xstart, ystart, size) = (first.x, first.y, second.y - first.y);
-
-    let mut xmax: u64 = 0;
-    let mut ymax: u64 = 0;
-    let mut xyz: HashMap<(u64, u64), f64> = HashMap::default();
-    let mut reader = XyzInternalReader::open(&xyz_file_in).unwrap();
-    while let Some(r) = reader.next()? {
-        let (x, y, h) = (r.x, r.y, r.z);
-
-        let xx = ((x - xstart) / size).floor() as u64;
-        let yy = ((y - ystart) / size).floor() as u64;
-        xyz.insert((xx, yy), h);
-        if xmax < xx {
-            xmax = xx;
-        }
-        if ymax < yy {
-            ymax = yy;
-        }
-    }
-
-    println!("xmax: {}, ymax: {}, len: {}", xmax, ymax, xyz.len());
+    // println!("xmax: {}, ymax: {}, len: {}", xmax, ymax, xyz.len());
     // load the binary file
     let heightmap_in = tmpfolder.join("xyz_03.xyz.bin.hmap");
     let mut reader = BufReader::new(File::open(heightmap_in)?);
@@ -942,17 +942,19 @@ pub fn xyzknolls(config: &Config, tmpfolder: &Path) -> Result<(), Box<dyn Error>
 
     let xmax = hmap.grid.width();
     let ymax = hmap.grid.height();
+    let size = hmap.scale;
+    let xstart = hmap.xoffset;
+    let ystart = hmap.yoffset;
 
-    let mut xyz_new: HashMap<(u64, u64), f64> = HashMap::default();
-    for (i, j, h) in hmap.grid.iter_idx() {
-        xyz_new.insert((i as u64, j as u64), h);
-    }
+    // let mut xyz_new: HashMap<(u64, u64), f64> = HashMap::default();
+    // for (i, j, h) in hmap.grid.iter_idx() {
+    //     xyz_new.insert((i as u64, j as u64), h);
+    // }
     println!(
-        "xmax: {}, ymax: {}, len: {}, equal: {}",
+        "xmax: {}, ymax: {}",
         xmax,
         ymax,
-        xyz.len(),
-        xyz == xyz_new
+        // xyz_new.len(),
     );
 
     let mut xyz2 = hmap.clone();

--- a/src/main.rs
+++ b/src/main.rs
@@ -253,10 +253,6 @@ fn main() {
         let xyzfilein = args[1].clone();
         let xyzfileout = args[2].clone();
         let dxffile = args[3].clone();
-        // let mut ground: bool = false;
-        // if args.len() > 4 && args[4] == "ground" {
-        //     ground = true;
-        // }
         let hmap =
             pullauta::contours::xyz2heightmap(&config, &tmpfolder, cinterval, &xyzfilein).unwrap();
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -253,20 +253,18 @@ fn main() {
         let xyzfilein = args[1].clone();
         let xyzfileout = args[2].clone();
         let dxffile = args[3].clone();
-        let mut ground: bool = false;
-        if args.len() > 4 && args[4] == "ground" {
-            ground = true;
+        // let mut ground: bool = false;
+        // if args.len() > 4 && args[4] == "ground" {
+        //     ground = true;
+        // }
+        let hmap =
+            pullauta::contours::xyz2heightmap(&config, &tmpfolder, cinterval, &xyzfilein).unwrap();
+
+        if xyzfileout != "null" && !xyzfileout.is_empty() {
+            hmap.to_file(xyzfileout).unwrap();
         }
-        pullauta::contours::xyz2contours(
-            &config,
-            &tmpfolder,
-            cinterval,
-            &xyzfilein,
-            &xyzfileout,
-            &dxffile,
-            ground,
-        )
-        .unwrap();
+
+        pullauta::contours::heightmap2contours(&tmpfolder, cinterval, &hmap, &dxffile).unwrap();
         return;
     }
 

--- a/src/merge.rs
+++ b/src/merge.rs
@@ -527,7 +527,7 @@ pub fn smoothjoin(config: &Config, tmpfolder: &Path) -> Result<(), Box<dyn Error
 
     let interval = halfinterval;
 
-    let heightmap_in = tmpfolder.join("xyz_knolls.xyz.bin.hmap");
+    let heightmap_in = tmpfolder.join("xyz_knolls.hmap");
     let mut reader = BufReader::new(File::open(heightmap_in)?);
     let hmap = HeightMap::from_bytes(&mut reader)?;
 

--- a/src/merge.rs
+++ b/src/merge.rs
@@ -540,7 +540,7 @@ pub fn smoothjoin(config: &Config, tmpfolder: &Path) -> Result<(), Box<dyn Error
 
     // Temporarily convert to HashMap for not having to go through all the logic below.
     let mut xyz: HashMap<(u64, u64), f64> = HashMap::default();
-    for (x, y, h) in hmap.grid.iter_idx() {
+    for (x, y, h) in hmap.grid.iter() {
         xyz.insert((x as u64, y as u64), h);
     }
 

--- a/src/process.rs
+++ b/src/process.rs
@@ -14,7 +14,7 @@ use crate::config::Config;
 use crate::contours;
 use crate::crop;
 use crate::io::heightmap::HeightMap;
-use crate::io::xyz::{XyzInternalWriter, XyzRecordMeta};
+use crate::io::xyz::XyzInternalWriter;
 use crate::knolls;
 use crate::merge;
 use crate::render;
@@ -138,8 +138,7 @@ pub fn process_tile(
             thread_name,
         );
 
-        let mut writer = XyzInternalWriter::create(&target_file, crate::io::xyz::Format::XyzMeta)
-            .expect("Could not create writer");
+        let mut writer = XyzInternalWriter::create(&target_file).expect("Could not create writer");
         read_lines_no_alloc(input_file, |line| {
             let mut parts = line.split(' ');
             let x = parts.next().unwrap().parse::<f64>().unwrap();
@@ -155,11 +154,9 @@ pub fn process_tile(
                     x,
                     y,
                     z,
-                    meta: Some(XyzRecordMeta {
-                        classification,
-                        number_of_returns,
-                        return_number,
-                    }),
+                    classification,
+                    number_of_returns,
+                    return_number,
                 })
                 .expect("Could not write record");
         })
@@ -188,8 +185,7 @@ pub fn process_tile(
 
         let mut reader = Reader::from_path(input_file).expect("Unable to open reader");
 
-        let mut writer =
-            XyzInternalWriter::create(&target_file, crate::io::xyz::Format::XyzMeta).unwrap();
+        let mut writer = XyzInternalWriter::create(&target_file).unwrap();
 
         for ptu in reader.points() {
             let pt = ptu.unwrap();
@@ -198,11 +194,9 @@ pub fn process_tile(
                     x: pt.x * xfactor,
                     y: pt.y * yfactor,
                     z: pt.z * zfactor + zoff,
-                    meta: Some(XyzRecordMeta {
-                        classification: u8::from(pt.classification),
-                        number_of_returns: pt.number_of_returns,
-                        return_number: pt.return_number,
-                    }),
+                    classification: u8::from(pt.classification),
+                    number_of_returns: pt.number_of_returns,
+                    return_number: pt.return_number,
                 })?;
             }
         }
@@ -447,8 +441,7 @@ pub fn batch_process(conf: &Config, thread: &String) {
         let maxy2 = maxy + 127.0;
 
         let tmp_filename = PathBuf::from(format!("temp{}.xyz.bin", thread));
-        let mut writer = XyzInternalWriter::create(&tmp_filename, crate::io::xyz::Format::XyzMeta)
-            .expect("Could not create writer");
+        let mut writer = XyzInternalWriter::create(&tmp_filename).expect("Could not create writer");
 
         for laz_p in &laz_files {
             let laz = laz_p.as_path().file_name().unwrap().to_str().unwrap();
@@ -473,11 +466,9 @@ pub fn batch_process(conf: &Config, thread: &String) {
                                 x: pt.x,
                                 y: pt.y,
                                 z: pt.z + zoff,
-                                meta: Some(XyzRecordMeta {
-                                    classification: u8::from(pt.classification),
-                                    number_of_returns: pt.number_of_returns,
-                                    return_number: pt.return_number,
-                                }),
+                                classification: u8::from(pt.classification),
+                                number_of_returns: pt.number_of_returns,
+                                return_number: pt.return_number,
                             })
                             .expect("Could not write record");
                     }

--- a/src/process.rs
+++ b/src/process.rs
@@ -231,10 +231,10 @@ pub fn process_tile(
             config,
             tmpfolder,
             scalefactor * 0.3,
-            "xyztemp.xyz.bin",
-            "xyz_03.xyz.bin",
-            "null",
-            true,
+            "xyztemp.xyz.bin", //point cloud in
+            "xyz_03.xyz.bin",  // heightmap out
+            "null",            // no dxf curves
+            true,              // only 2 or water_class points
         )
         .expect("contour generation failed");
     } else {
@@ -242,14 +242,15 @@ pub fn process_tile(
             config,
             tmpfolder,
             scalefactor * 0.3,
-            "xyztemp.xyz.bin",
-            "xyz_03.xyz.bin",
-            "contours03.dxf",
-            true,
+            "xyztemp.xyz.bin", // point cloud in
+            "xyz_03.xyz.bin",  // heightmap out
+            "contours03.dxf",  // dxf curves generated from the heightmap
+            true,              // only 2 or water_class points
         )
         .expect("contour generation failed");
     }
 
+    // copy the generated heightmap
     fs::copy(
         tmpfolder.join("xyz_03.xyz.bin"),
         tmpfolder.join("xyz2.xyz.bin"),
@@ -270,10 +271,10 @@ pub fn process_tile(
                 config,
                 tmpfolder,
                 basemapcontours,
-                "xyz2.xyz.bin",
-                "",
-                "basemap.dxf",
-                false,
+                "xyz2.xyz.bin", // heightmap in
+                "",             // no heightmap out
+                "basemap.dxf",  // generate dxf contours
+                false,          // include all points
             )
             .expect("contour generation failed");
         }
@@ -284,7 +285,7 @@ pub fn process_tile(
         }
         info!("{}Contour generation part 1", thread_name);
         timing.start_section("contour generation part 1");
-        knolls::xyzknolls(config, tmpfolder).unwrap();
+        knolls::xyzknolls(config, tmpfolder).unwrap(); // modifies the heightmap (but does not change dimensions
 
         info!("{}Contour generation part 2", thread_name);
         timing.start_section("contour generation part 2");
@@ -294,10 +295,10 @@ pub fn process_tile(
                 config,
                 tmpfolder,
                 halfinterval,
-                "xyz_knolls.xyz.bin",
-                "null",
-                "out.dxf",
-                false,
+                "xyz_knolls.xyz.bin", // heightmap in
+                "null",               // no heightmap out
+                "out.dxf",            // generates dxf curves
+                false,                // includes all points
             )
             .unwrap();
         } else {
@@ -305,10 +306,10 @@ pub fn process_tile(
                 config,
                 tmpfolder,
                 halfinterval,
-                "xyztemp.xyz.bin",
-                "null",
-                "out.dxf",
-                true,
+                "xyztemp.xyz.bin", // point cloud in
+                "null",            // do not save the heightmap
+                "out.dxf",         // generate dxf curves
+                true,              // include only ground classified points or water
             )
             .unwrap();
         }

--- a/src/process.rs
+++ b/src/process.rs
@@ -228,9 +228,7 @@ pub fn process_tile(
         "xyztemp.xyz.bin", //point cloud in
     )
     .expect("contour generation failed");
-    xyz_03
-        .to_file(tmpfolder.join("xyz_03.xyz.bin.hmap"))
-        .unwrap();
+    xyz_03.to_file(tmpfolder.join("xyz_03.hmap")).unwrap();
 
     if vegeonly || cliffsonly {
     } else {
@@ -245,11 +243,8 @@ pub fn process_tile(
     drop(xyz_03);
 
     // copy the generated heightmap
-    fs::copy(
-        tmpfolder.join("xyz_03.xyz.bin.hmap"),
-        tmpfolder.join("xyz2.xyz.bin.hmap"),
-    )
-    .expect("Could not copy file");
+    fs::copy(tmpfolder.join("xyz_03.hmap"), tmpfolder.join("xyz2.hmap"))
+        .expect("Could not copy file");
 
     let &Config {
         contour_interval,
@@ -261,7 +256,7 @@ pub fn process_tile(
     if !vegeonly && !cliffsonly {
         if basemapcontours != 0.0 {
             info!("{}Basemap contours", thread_name);
-            let xyz2 = HeightMap::from_file(tmpfolder.join("xyz2.xyz.bin.hmap"))
+            let xyz2 = HeightMap::from_file(tmpfolder.join("xyz2.hmap"))
                 .expect("could not read xyz2 heightmap");
             contours::heightmap2contours(
                 tmpfolder,
@@ -284,7 +279,7 @@ pub fn process_tile(
         timing.start_section("contour generation part 2");
         if !skipknolldetection {
             // contours 2.5
-            let xyz_knolls = HeightMap::from_file(tmpfolder.join("xyz_knolls.xyz.bin.hmap"))
+            let xyz_knolls = HeightMap::from_file(tmpfolder.join("xyz_knolls.hmap"))
                 .expect("could not read xyz_knolls heightmap");
             contours::heightmap2contours(
                 tmpfolder,

--- a/src/process.rs
+++ b/src/process.rs
@@ -257,6 +257,12 @@ pub fn process_tile(
     )
     .expect("Could not copy file");
 
+    fs::copy(
+        tmpfolder.join("xyz_03.xyz.bin.hmap"),
+        tmpfolder.join("xyz2.xyz.bin.hmap"),
+    )
+    .expect("Could not copy file");
+
     let &Config {
         contour_interval,
         basemapcontours,

--- a/src/render.rs
+++ b/src/render.rs
@@ -1225,7 +1225,7 @@ pub fn draw_curves(
     let mut steepness: HashMap<(usize, usize), f64> = HashMap::default();
 
     if formline > 0.0 {
-        let heightmap_in = tmpfolder.join("xyz2.xyz.bin.hmap");
+        let heightmap_in = tmpfolder.join("xyz2.hmap");
         let mut reader = BufReader::new(File::open(heightmap_in)?);
         let hmap = HeightMap::from_bytes(&mut reader)?;
 

--- a/src/render.rs
+++ b/src/render.rs
@@ -1237,7 +1237,7 @@ pub fn draw_curves(
 
         // Temporarily convert to HashMap for not having to go through all the logic below.
         let mut xyz: HashMap<(usize, usize), f64> = HashMap::default();
-        for (x, y, h) in hmap.grid.iter_idx() {
+        for (x, y, h) in hmap.grid.iter() {
             xyz.insert((x, y), h);
         }
         y0 = hmap.maxy();

--- a/src/vec2d.rs
+++ b/src/vec2d.rs
@@ -30,6 +30,14 @@ impl<T> Vec2D<T> {
     // fn mem_used(&self) -> usize {
     //     std::mem::size_of_val(&self.data)
     // }
+    pub fn iter_idx_mut(&mut self) -> impl Iterator<Item = (usize, usize, &mut T)> + '_ {
+        let h = self.h;
+        self.data.iter_mut().enumerate().map(move |(i, v)| {
+            let x = i / h;
+            let y = i % h;
+            (x, y, v)
+        })
+    }
 }
 
 impl<T: Copy> Vec2D<T> {

--- a/src/vec2d.rs
+++ b/src/vec2d.rs
@@ -27,8 +27,18 @@ impl<T> Vec2D<T> {
         self.h
     }
 
-    fn mem_used(&self) -> usize {
-        std::mem::size_of_val(&self.data)
+    // fn mem_used(&self) -> usize {
+    //     std::mem::size_of_val(&self.data)
+    // }
+}
+
+impl<T: Copy> Vec2D<T> {
+    pub fn iter_idx(&self) -> impl Iterator<Item = (usize, usize, T)> + '_ {
+        self.data.iter().enumerate().map(move |(i, v)| {
+            let x = i / self.h;
+            let y = i % self.h;
+            (x, y, *v)
+        })
     }
 }
 

--- a/src/vec2d.rs
+++ b/src/vec2d.rs
@@ -27,10 +27,7 @@ impl<T> Vec2D<T> {
         self.h
     }
 
-    // fn mem_used(&self) -> usize {
-    //     std::mem::size_of_val(&self.data)
-    // }
-    pub fn iter_idx_mut(&mut self) -> impl Iterator<Item = (usize, usize, &mut T)> + '_ {
+    pub fn iter_mut(&mut self) -> impl Iterator<Item = (usize, usize, &mut T)> + '_ {
         let h = self.h;
         self.data.iter_mut().enumerate().map(move |(i, v)| {
             let x = i / h;
@@ -41,7 +38,7 @@ impl<T> Vec2D<T> {
 }
 
 impl<T: Copy> Vec2D<T> {
-    pub fn iter_idx(&self) -> impl Iterator<Item = (usize, usize, T)> + '_ {
+    pub fn iter(&self) -> impl Iterator<Item = (usize, usize, T)> + '_ {
         self.data.iter().enumerate().map(move |(i, v)| {
             let x = i / self.h;
             let y = i % self.h;

--- a/src/vec2d.rs
+++ b/src/vec2d.rs
@@ -1,7 +1,7 @@
 use crate::io::bytes::FromToBytes;
 
 /// Vector for storing 2-dimensional grid-like data in a contigous memory block, removes one layer of indirection.
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, PartialEq)]
 pub struct Vec2D<T> {
     data: Box<[T]>, // the size is fixed, so we can use a Box slice instead of Vec
     w: usize,

--- a/src/vegetation.rs
+++ b/src/vegetation.rs
@@ -18,7 +18,7 @@ use crate::io::xyz::XyzInternalReader;
 pub fn makevege(config: &Config, tmpfolder: &Path) -> Result<(), Box<dyn Error>> {
     info!("Generating vegetation...");
 
-    let heightmap_in = tmpfolder.join("xyz2.xyz.bin.hmap");
+    let heightmap_in = tmpfolder.join("xyz2.hmap");
     let mut reader = BufReader::new(File::open(heightmap_in)?);
     let hmap = HeightMap::from_bytes(&mut reader)?;
 

--- a/src/vegetation.rs
+++ b/src/vegetation.rs
@@ -77,10 +77,9 @@ pub fn makevege(config: &Config, tmpfolder: &Path) -> Result<(), Box<dyn Error>>
             let x: f64 = r.x;
             let y: f64 = r.y;
             let h: f64 = r.z;
-            let m = r.meta.unwrap();
-            let r3 = m.classification;
-            let r4 = m.number_of_returns;
-            let r5 = m.return_number;
+            let r3 = r.classification;
+            let r4 = r.number_of_returns;
+            let r5 = r.return_number;
 
             if xmax < x {
                 xmax = x;
@@ -135,10 +134,9 @@ pub fn makevege(config: &Config, tmpfolder: &Path) -> Result<(), Box<dyn Error>>
             let x: f64 = r.x;
             let y: f64 = r.y;
             let h: f64 = r.z - zoffset;
-            let m = r.meta.unwrap();
-            let r3 = m.classification;
-            let r4 = m.number_of_returns;
-            let r5 = m.return_number;
+            let r3 = r.classification;
+            let r4 = r.number_of_returns;
+            let r5 = r.return_number;
 
             if x > xmin && y > ymin {
                 if r5 == 1 {
@@ -425,8 +423,7 @@ pub fn makevege(config: &Config, tmpfolder: &Path) -> Result<(), Box<dyn Error>>
         let mut reader = XyzInternalReader::open(&xyz_file_in)?;
         while let Some(r) = reader.next()? {
             let (x, y) = (r.x, r.y);
-
-            let c: u8 = r.meta.unwrap().classification;
+            let c: u8 = r.classification;
 
             if c == buildings {
                 draw_filled_rect_mut(

--- a/src/vegetation.rs
+++ b/src/vegetation.rs
@@ -29,7 +29,7 @@ pub fn makevege(config: &Config, tmpfolder: &Path) -> Result<(), Box<dyn Error>>
 
     // Temporarily convert to HashMap for not having to go through all the logic below.
     let mut xyz: HashMap<(u64, u64), f64> = HashMap::default();
-    for (x, y, h) in hmap.grid.iter_idx() {
+    for (x, y, h) in hmap.grid.iter() {
         xyz.insert((x as u64, y as u64), h);
     }
 
@@ -445,7 +445,7 @@ pub fn makevege(config: &Config, tmpfolder: &Path) -> Result<(), Box<dyn Error>>
         }
     }
 
-    for (x, y, hh) in hmap.iter_values() {
+    for (x, y, hh) in hmap.iter() {
         if hh < config.waterele {
             draw_filled_rect_mut(
                 &mut imgwater,


### PR DESCRIPTION
- Store the heightmap-like data that was previously stored as binary XYZ files in a format more suitable for a grid in a `.hmap` file. Uses the `Vec2d` and stores it together with additional metadata like the `x` and `y` offsets as well as the `scale`.  This means we do not have to iterate all points to find min/max values etc and we can also directly index into the 2d-array instead of doing `HashMap` lookups (although in a few places I left the `HashMap` and just created it from the grid directly. This is to avoid having to go through those quite complicated algorithms in this PR. Instead here we just make sure we didn't break anything :smile: )
- Went through `contours.rs` and figured that the `xyz2contours` function was actually performing _2 functions_. So I split it into two:  `xyz2heightmap` creates a `HeightMap` from a XYZ point cloud, `heightmap2contours` converts such a heightmap into `dxf` contours. This was also needed to do the change above and introduce the `HeightMap` type since the function was treating all input (either point cloud or heightmap-style as point cloud inputs).
- To aid in reading and writing these binary formats, I decided to add a simple trait `FromToBytes` that can write `self` into a writer and construct `Self` from a reader. This makes the implementation quite simple and readable IMO :rocket: 
- The `Format` used to indicate whether the internal XYZ file contained point metadata or only points is no longer needed (it was used only for representing the height maps as XYZ files) , and has thus been removed. This simplifies the data format quite a bit.
- Command `internal2xyz` has been updated to support generating the old-style XYZ files from the new `.hmap` files.