### PR TITLE
Feature/fs trait

### DIFF
--- a/pullauta.default.ini
+++ b/pullauta.default.ini
@@ -221,14 +221,6 @@ vege_bitmode=0
 # label_formlines_depressions, set to 1 to add a seperate label on the depressions in the formlines vector file
 label_formlines_depressions=0
 
-# vegeonly, set to 1 to only generate the vegetations related files and skip the rest
-vegeonly=0
-# contoursonly, set to 1 to only generate the contours related files and skip the rest
-contoursonly=0
-# cliffsonly, set to 1 to only generate the cliffs related files and skip the rest
-cliffsonly=0
-# Only one of vegeonly contoursonly and cliffsonly can be set at a time
-
 
 #------------------------------------------------------#
 #              EXPERIMENTAL OPTIONS                    #
@@ -238,4 +230,13 @@ cliffsonly=0
 # Set experimental_use_in_memory_fs to 1 to use an in-memory filesystem for all temporary files.
 # This is useful when the files are small enough to fit in memory as it reduces
 # the amount of I/O needed on the cost of using more RAM.
-experimental_use_in_memory_fs=1
+experimental_use_in_memory_fs=0
+
+
+# vegeonly, set to 1 to only generate the vegetations related files and skip the rest
+vegeonly=0
+# contoursonly, set to 1 to only generate the contours related files and skip the rest
+contoursonly=0
+# cliffsonly, set to 1 to only generate the cliffs related files and skip the rest
+cliffsonly=0
+# Only one of vegeonly contoursonly and cliffsonly can be set at a time

--- a/pullauta.default.ini
+++ b/pullauta.default.ini
@@ -197,11 +197,6 @@ savetempfolders=0
 # the interval of additonal dxf contour layer (raw, for mapping). 0 = disabled. Value 1.125 gives such interval contours
 basemapinterval=0
 
-# Experimental parameters. Dont chance these unless you feel like experimenting
-scalefactor=1
-zoffset=0
-#skipknolldetection=0
-
 ##################################################################################################################################
 # Settings specific to the rust version of karttapulautin, default values are meant to be fidel to original Perl Karttapullautin #
 ##################################################################################################################################
@@ -221,6 +216,13 @@ vege_bitmode=0
 # label_formlines_depressions, set to 1 to add a seperate label on the depressions in the formlines vector file
 label_formlines_depressions=0
 
+# vegeonly, set to 1 to only generate the vegetations related files and skip the rest
+vegeonly=0
+# contoursonly, set to 1 to only generate the contours related files and skip the rest
+contoursonly=0
+# cliffsonly, set to 1 to only generate the cliffs related files and skip the rest
+cliffsonly=0
+# Only one of vegeonly contoursonly and cliffsonly can be set at a time
 
 #------------------------------------------------------#
 #              EXPERIMENTAL OPTIONS                    #
@@ -232,11 +234,7 @@ label_formlines_depressions=0
 # the amount of I/O needed on the cost of using more RAM.
 experimental_use_in_memory_fs=0
 
-
-# vegeonly, set to 1 to only generate the vegetations related files and skip the rest
-vegeonly=0
-# contoursonly, set to 1 to only generate the contours related files and skip the rest
-contoursonly=0
-# cliffsonly, set to 1 to only generate the cliffs related files and skip the rest
-cliffsonly=0
-# Only one of vegeonly contoursonly and cliffsonly can be set at a time
+# Experimental parameters. Dont change these unless you feel like experimenting
+scalefactor=1
+zoffset=0
+#skipknolldetection=0

--- a/pullauta.default.ini
+++ b/pullauta.default.ini
@@ -229,3 +229,13 @@ contoursonly=0
 cliffsonly=0
 # Only one of vegeonly contoursonly and cliffsonly can be set at a time
 
+
+#------------------------------------------------------#
+#              EXPERIMENTAL OPTIONS                    #
+#            (No stability guarantees)                 #
+#----------------------------------------------------- #
+
+# Set experimental_use_in_memory_fs to 1 to use an in-memory filesystem for all temporary files.
+# This is useful when the files are small enough to fit in memory as it reduces
+# the amount of I/O needed on the cost of using more RAM.
+experimental_use_in_memory_fs=1

--- a/src/blocks.rs
+++ b/src/blocks.rs
@@ -6,9 +6,9 @@ use log::info;
 use rustc_hash::FxHashMap as HashMap;
 use std::{error::Error, fs::File, io::BufReader, path::Path};
 
-use crate::io::{bytes::FromToBytes, heightmap::HeightMap, xyz::XyzInternalReader};
+use crate::io::{bytes::FromToBytes, fs::FileSystem, heightmap::HeightMap, xyz::XyzInternalReader};
 
-pub fn blocks(tmpfolder: &Path) -> Result<(), Box<dyn Error>> {
+pub fn blocks(fs: &impl FileSystem, tmpfolder: &Path) -> Result<(), Box<dyn Error>> {
     info!("Identifying blocks...");
 
     let heightmap_in = tmpfolder.join("xyz2.hmap");
@@ -35,7 +35,8 @@ pub fn blocks(tmpfolder: &Path) -> Result<(), Box<dyn Error>> {
     let white = Rgba([255, 255, 255, 255]);
 
     let xyz_file_in = tmpfolder.join("xyztemp.xyz.bin");
-    let mut reader = XyzInternalReader::open(&xyz_file_in).unwrap();
+    let file = BufReader::new(fs.open(&xyz_file_in)?);
+    let mut reader = XyzInternalReader::new(file).unwrap();
     while let Some(r) = reader.next().unwrap() {
         let (x, y, h) = (r.x, r.y, r.z);
         let r3 = r.classification;

--- a/src/blocks.rs
+++ b/src/blocks.rs
@@ -4,7 +4,7 @@ use imageproc::filter::median_filter;
 use imageproc::rect::Rect;
 use log::info;
 use rustc_hash::FxHashMap as HashMap;
-use std::{error::Error, fs::File, io::BufReader, path::Path};
+use std::{error::Error, io::BufReader, path::Path};
 
 use crate::io::{bytes::FromToBytes, fs::FileSystem, heightmap::HeightMap, xyz::XyzInternalReader};
 
@@ -12,7 +12,7 @@ pub fn blocks(fs: &impl FileSystem, tmpfolder: &Path) -> Result<(), Box<dyn Erro
     info!("Identifying blocks...");
 
     let heightmap_in = tmpfolder.join("xyz2.hmap");
-    let mut reader = BufReader::new(File::open(heightmap_in)?);
+    let mut reader = BufReader::new(fs.open(heightmap_in)?);
     let hmap = HeightMap::from_bytes(&mut reader)?;
 
     let xstartxyz = hmap.xoffset;

--- a/src/blocks.rs
+++ b/src/blocks.rs
@@ -69,8 +69,13 @@ pub fn blocks(fs: &impl FileSystem, tmpfolder: &Path) -> Result<(), Box<dyn Erro
         }
     }
 
-    img2.save(tmpfolder.join("blocks2.png"))
-        .expect("error saving png");
+    img2.write_to(
+        &mut fs
+            .create(tmpfolder.join("blocks2.png"))
+            .expect("error saving png"),
+        image::ImageFormat::Png,
+    )
+    .expect("error saving png");
 
     let mut img = DynamicImage::ImageRgb8(img);
 
@@ -79,8 +84,13 @@ pub fn blocks(fs: &impl FileSystem, tmpfolder: &Path) -> Result<(), Box<dyn Erro
     let filter_size = 2;
     img = image::DynamicImage::ImageRgb8(median_filter(&img.to_rgb8(), filter_size, filter_size));
 
-    img.save(tmpfolder.join("blocks.png"))
-        .expect("error saving png");
+    img.write_to(
+        &mut fs
+            .create(tmpfolder.join("blocks.png"))
+            .expect("error saving png"),
+        image::ImageFormat::Png,
+    )
+    .expect("error saving png");
     info!("Done");
     Ok(())
 }

--- a/src/cliffs.rs
+++ b/src/cliffs.rs
@@ -353,8 +353,15 @@ pub fn makecliffs(
 
     f3.write_all(b"ENDSEC\r\n  0\r\nEOF\r\n")
         .expect("Cannot write dxf file");
-    img.save(tmpfolder.join("c2.png"))
-        .expect("could not save output png");
+
+    img.write_to(
+        &mut fs
+            .create(tmpfolder.join("c2.png"))
+            .expect("could not save output png"),
+        image::ImageFormat::Png,
+    )
+    .expect("could not save output png");
+
     info!("Done");
     Ok(())
 }

--- a/src/config.rs
+++ b/src/config.rs
@@ -7,6 +7,8 @@ pub struct Config {
     pub batch: bool,
     pub processes: u64,
 
+    pub experimental_use_in_memory_fs: bool,
+
     // only one can be set at a time
     pub vegeonly: bool,
     pub cliffsonly: bool,
@@ -152,6 +154,8 @@ impl Config {
         let pnorthlineswidth: usize = parse_typed(gs, "northlineswidth", 0);
 
         let processes: u64 = gs.get("processes").unwrap().parse::<u64>().unwrap();
+        let experimental_use_in_memory_fs: bool =
+            gs.get("experimental_use_in_memory_fs").unwrap_or("0") == "1";
 
         let lazfolder = gs.get("lazfolder").unwrap_or("").to_string();
         let batchoutfolder = gs.get("batchoutfolder").unwrap_or("").to_string();
@@ -327,6 +331,7 @@ impl Config {
         Ok(Self {
             batch: gs.get("batch").unwrap() == "1",
             processes,
+            experimental_use_in_memory_fs,
             vegeonly,
             cliffsonly,
             contoursonly,

--- a/src/contours.rs
+++ b/src/contours.rs
@@ -1,11 +1,11 @@
 use log::info;
 use rustc_hash::FxHashMap as HashMap;
 use std::error::Error;
-use std::fs::File;
 use std::io::{BufReader, BufWriter, Write};
 use std::path::Path;
 
 use crate::config::Config;
+use crate::io::fs::FileSystem;
 use crate::io::heightmap::HeightMap;
 use crate::io::xyz::XyzInternalReader;
 use crate::util::read_lines_no_alloc;
@@ -15,6 +15,7 @@ use crate::vec2d::Vec2D;
 ///
 /// Loads all the points and uses those that are classified as ground or water to create a heightmap using averages.
 pub fn xyz2heightmap(
+    fs: &impl FileSystem,
     config: &Config,
     tmpfolder: &Path,
     xyzfilein: &str, // this should be point cloud in
@@ -34,7 +35,7 @@ pub fn xyz2heightmap(
     let mut hmax: f64 = f64::MIN;
 
     let xyz_file_in = tmpfolder.join(xyzfilein);
-    let mut reader = XyzInternalReader::new(BufReader::new(std::fs::File::open(&xyz_file_in)?))?;
+    let mut reader = XyzInternalReader::new(BufReader::new(fs.open(&xyz_file_in)?))?;
     while let Some(r) = reader.next()? {
         if r.classification == 2 || r.classification == water_class {
             let x: f64 = r.x;
@@ -77,7 +78,7 @@ pub fn xyz2heightmap(
     // a two-dimensional vector of (sum, count) pairs for computing averages
     let mut list_alt = Vec2D::new(w + 2, h + 2, (0f64, 0usize));
 
-    let mut reader = XyzInternalReader::new(BufReader::new(std::fs::File::open(&xyz_file_in)?))?;
+    let mut reader = XyzInternalReader::new(BufReader::new(fs.open(&xyz_file_in)?))?;
     while let Some(r) = reader.next()? {
         if r.classification == 2 || r.classification == water_class {
             let x: f64 = r.x;
@@ -227,6 +228,7 @@ pub fn xyz2heightmap(
 
 /// Creates contour lines from a heightmap.
 pub fn heightmap2contours(
+    fs: &impl FileSystem,
     tmpfolder: &Path,
     cinterval: f64,
     heightmap: &HeightMap,
@@ -270,7 +272,7 @@ pub fn heightmap2contours(
     let mut level: f64 = (hmin / v).floor() * v;
     let polyline_out = tmpfolder.join("temp_polylines.txt");
 
-    let f = File::create(&polyline_out).expect("Unable to create file");
+    let f = fs.create(&polyline_out).expect("Unable to create file");
     let mut f = BufWriter::new(f);
 
     loop {
@@ -492,7 +494,9 @@ pub fn heightmap2contours(
     // explicitly flush and drop to close the file
     drop(f);
 
-    let f = File::create(tmpfolder.join(dxffile)).expect("Unable to create file");
+    let f = fs
+        .create(tmpfolder.join(dxffile))
+        .expect("Unable to create file");
     let mut f = BufWriter::new(f);
 
     write!(
@@ -501,7 +505,7 @@ pub fn heightmap2contours(
         xmin, ymin, xmax, ymax,
     ).expect("Cannot write dxf file");
 
-    read_lines_no_alloc(polyline_out, |line| {
+    read_lines_no_alloc(fs, polyline_out, |line| {
         let parts = line.trim().split(';');
         let r = parts.collect::<Vec<&str>>();
         f.write_all("POLYLINE\r\n 66\r\n1\r\n  8\r\ncont\r\n  0\r\n".as_bytes())

--- a/src/crop.rs
+++ b/src/crop.rs
@@ -1,9 +1,11 @@
 use std::error::Error;
-use std::fs::{self, File};
 use std::io::{BufWriter, Write};
 use std::path::Path;
 
+use crate::io::fs::FileSystem;
+
 pub fn polylinedxfcrop(
+    fs: &impl FileSystem,
     input: &Path,
     output: &Path,
     minx: f64,
@@ -11,7 +13,9 @@ pub fn polylinedxfcrop(
     maxx: f64,
     maxy: f64,
 ) -> Result<(), Box<dyn Error>> {
-    let data = fs::read_to_string(input).expect("Should have been able to read the file");
+    let data = fs
+        .read_to_string(input)
+        .expect("Should have been able to read the file");
     let data: Vec<&str> = data.split("POLYLINE").collect();
     let dxfhead = data[0];
     let mut out = String::new();
@@ -77,13 +81,14 @@ pub fn polylinedxfcrop(
     if !out.contains("EOF") {
         out.push_str("ENDSEC\r\n  0\r\nEOF\r\n");
     }
-    let fp = File::create(output).expect("Unable to create file");
+    let fp = fs.create(output).expect("Unable to create file");
     let mut fp = BufWriter::new(fp);
     fp.write_all(out.as_bytes()).expect("Unable to write file");
     Ok(())
 }
 
 pub fn pointdxfcrop(
+    fs: &impl FileSystem,
     input: &Path,
     output: &Path,
     minx: f64,
@@ -91,11 +96,13 @@ pub fn pointdxfcrop(
     maxx: f64,
     maxy: f64,
 ) -> Result<(), Box<dyn Error>> {
-    let data = fs::read_to_string(input).expect("Should have been able to read the file");
+    let data = fs
+        .read_to_string(input)
+        .expect("Should have been able to read the file");
     let mut data: Vec<&str> = data.split("POINT").collect();
     let dxfhead = data[0];
 
-    let fp = File::create(output).expect("Unable to create file");
+    let fp = fs.create(output).expect("Unable to create file");
     let mut fp = BufWriter::new(fp);
 
     fp.write_all(dxfhead.as_bytes())

--- a/src/io/fs/local.rs
+++ b/src/io/fs/local.rs
@@ -1,0 +1,54 @@
+use std::io::{self, Read, Seek, Write};
+use std::path::{Path, PathBuf};
+
+use super::FileSystem;
+
+/// [`FileSystem`] implementation for the local file system.
+#[derive(Clone)]
+pub struct LocalFileSystem;
+
+impl FileSystem for LocalFileSystem {
+    fn create_dir_all(&self, path: impl AsRef<Path>) -> Result<(), io::Error> {
+        std::fs::create_dir_all(path)
+    }
+
+    fn list(&self, path: impl AsRef<Path>) -> Result<Vec<PathBuf>, io::Error> {
+        let path = path.as_ref();
+        let mut entries = vec![];
+        for entry in std::fs::read_dir(path)? {
+            let entry = entry?;
+            entries.push(path.join(entry.file_name()));
+        }
+        Ok(entries)
+    }
+
+    fn exists(&self, path: impl AsRef<Path>) -> bool {
+        path.as_ref().exists()
+    }
+
+    fn read_to_string(&self, path: impl AsRef<Path>) -> Result<String, io::Error> {
+        std::fs::read_to_string(path)
+    }
+
+    fn open(&self, path: impl AsRef<Path>) -> Result<impl Read + Seek, io::Error> {
+        std::fs::File::open(path)
+    }
+
+    fn create(&self, path: impl AsRef<Path>) -> Result<impl Write + Seek, io::Error> {
+        std::fs::File::create(path)
+    }
+
+    fn remove_file(&self, path: impl AsRef<Path>) -> Result<(), io::Error> {
+        std::fs::remove_file(path)
+    }
+
+    fn file_size(&self, path: impl AsRef<Path>) -> Result<u64, io::Error> {
+        let metadata = std::fs::metadata(path)?;
+        Ok(metadata.len())
+    }
+
+    fn copy(&self, from: impl AsRef<Path>, to: impl AsRef<Path>) -> Result<(), io::Error> {
+        std::fs::copy(from, to)?;
+        Ok(())
+    }
+}

--- a/src/io/fs/local.rs
+++ b/src/io/fs/local.rs
@@ -4,7 +4,7 @@ use std::path::{Path, PathBuf};
 use super::FileSystem;
 
 /// [`FileSystem`] implementation for the local file system.
-#[derive(Clone)]
+#[derive(Debug, Clone)]
 pub struct LocalFileSystem;
 
 impl FileSystem for LocalFileSystem {
@@ -30,7 +30,7 @@ impl FileSystem for LocalFileSystem {
         std::fs::read_to_string(path)
     }
 
-    fn open(&self, path: impl AsRef<Path>) -> Result<impl Read + Seek, io::Error> {
+    fn open(&self, path: impl AsRef<Path>) -> Result<impl Read + Seek + Send + 'static, io::Error> {
         std::fs::File::open(path)
     }
 

--- a/src/io/fs/memory.rs
+++ b/src/io/fs/memory.rs
@@ -3,7 +3,7 @@ use rustc_hash::FxHashMap as HashMap;
 
 use core::str;
 use std::io::{self, Read, Seek, Write};
-use std::path::{Path, PathBuf};
+use std::path::{Component, Path, PathBuf};
 use std::sync::{Arc, RwLock};
 
 /// An in-memory implementation of [`FileSystem`] for use whenever there is no access to a local
@@ -73,7 +73,10 @@ impl Directory {
         let path = path.as_ref();
         let mut dir: &Directory = self;
         for component in path.components() {
-            let name = component.as_os_str().to_string_lossy().to_string();
+            let Component::Normal(component) = component else {
+                continue;
+            };
+            let name = component.to_string_lossy().to_string();
             dir = match dir.subdirs.get(&name) {
                 Some(subdir) => subdir,
                 None => {
@@ -91,7 +94,10 @@ impl Directory {
         let path = path.as_ref();
         let mut dir: &mut Directory = self;
         for component in path.components() {
-            let name = component.as_os_str().to_string_lossy().to_string();
+            let Component::Normal(component) = component else {
+                continue;
+            };
+            let name = component.to_string_lossy().to_string();
             dir = match dir.subdirs.get_mut(&name) {
                 Some(subdir) => subdir,
                 None => {
@@ -191,7 +197,10 @@ impl FileSystem for MemoryFileSystem {
         // make sure all directories in the path exist
         let mut dir: &mut Directory = &mut root;
         for component in path.components() {
-            let name = component.as_os_str().to_string_lossy().to_string();
+            let Component::Normal(component) = component else {
+                continue;
+            };
+            let name = component.to_string_lossy().to_string();
             dir = dir.subdirs.entry(name).or_insert_with(Directory::new);
         }
         Ok(())

--- a/src/io/fs/memory.rs
+++ b/src/io/fs/memory.rs
@@ -29,6 +29,29 @@ impl MemoryFileSystem {
             root: Arc::new(RwLock::new(Directory::new())),
         }
     }
+
+    /// Load the contents of a file on the local file system into the memory file system.
+    pub fn load_from_disk(
+        &self,
+        from_disk: impl AsRef<Path>,
+        to_internal: impl AsRef<Path>,
+    ) -> io::Result<()> {
+        let bytes = std::fs::read(from_disk)?;
+        let mut writer = self.create(to_internal)?;
+        writer.write_all(&bytes)?;
+        Ok(())
+    }
+    /// Write the contents of a  file in the memory file system to the local file system.
+    pub fn save_to_disk(
+        &self,
+        from_internal: impl AsRef<Path>,
+        to_external: impl AsRef<Path>,
+    ) -> io::Result<()> {
+        let mut reader = io::BufReader::new(self.open(from_internal)?);
+        let mut writer = io::BufWriter::new(std::fs::File::create(to_external)?);
+        std::io::copy(&mut reader, &mut writer)?;
+        Ok(())
+    }
 }
 
 #[derive(Debug)]

--- a/src/io/fs/memory.rs
+++ b/src/io/fs/memory.rs
@@ -1,0 +1,509 @@
+use super::FileSystem;
+use rustc_hash::FxHashMap as HashMap;
+
+use core::str;
+use std::io::{self, Read, Seek, Write};
+use std::path::{Path, PathBuf};
+use std::sync::{Arc, RwLock};
+
+/// An in-memory implementation of [`FileSystem`] for use whenever there is no access to a local
+/// file system (such as on WASM), or to speed up the processing when there is a lot of RAM available.
+///
+/// This object is thread-safe and can be shared between threads. Uses [`Arc`] internally so it is
+/// cheap to clone.
+#[derive(Debug, Clone)]
+pub struct MemoryFileSystem {
+    root: Arc<RwLock<Directory>>,
+}
+
+impl MemoryFileSystem {
+    /// Create a new empty memory file system.
+    pub fn new() -> Self {
+        Self {
+            root: Arc::new(RwLock::new(Directory::new())),
+        }
+    }
+}
+
+#[derive(Debug)]
+struct Directory {
+    subdirs: HashMap<String, Directory>,
+    files: HashMap<String, FileEntry>,
+}
+
+impl Directory {
+    /// Create a new empty directory.
+    fn new() -> Self {
+        Self {
+            subdirs: HashMap::default(),
+            files: HashMap::default(),
+        }
+    }
+}
+
+#[derive(Debug)]
+struct FileEntry {
+    /// data is stored as an Arc to allow for multiple readers.
+    /// Wrapped in an Arc to allow for swapping the value when the Writer is dropped / finished.
+    data: Arc<RwLock<FileData>>,
+}
+
+impl FileEntry {
+    /// Create a new empty file entry.
+    fn new() -> Self {
+        Self {
+            data: Arc::new(RwLock::new(FileData::new())),
+        }
+    }
+}
+impl std::fmt::Debug for FileData {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        let len = self.0.len();
+        f.debug_struct("FileData").field("len", &len).finish()
+    }
+}
+
+// TODO: these should implement Read, Write, Seek and be returned by the FileSystem methods
+struct WritableFile {
+    /// The data beeing written to the file
+    data: io::Cursor<Vec<u8>>,
+    /// links back to the file entry so we can swap the data when the writer is dropped
+    data_link: Arc<RwLock<FileData>>,
+}
+
+impl Write for WritableFile {
+    fn write(&mut self, buf: &[u8]) -> io::Result<usize> {
+        self.data.write(buf)
+    }
+
+    fn flush(&mut self) -> io::Result<()> {
+        self.data.flush()
+    }
+}
+
+impl Seek for WritableFile {
+    fn seek(&mut self, pos: io::SeekFrom) -> io::Result<u64> {
+        self.data.seek(pos)
+    }
+}
+
+impl Drop for WritableFile {
+    // swap the data into the file entry on drop
+    fn drop(&mut self) {
+        let data = core::mem::replace(&mut self.data, io::Cursor::new(Vec::new()));
+        let mut data_link = self.data_link.write().unwrap();
+        *data_link = FileData(Arc::new(data.into_inner()));
+    }
+}
+
+// struct ReadableFile(io::Cursor<Arc<[u8]>>);
+// struct ReadableFile(io::Cursor<Arc<Vec<u8>>>);
+/// Holds the data of a file. Cheap to clone because it is an Arc.
+#[derive(Clone)]
+struct FileData(Arc<Vec<u8>>);
+impl FileData {
+    fn new() -> Self {
+        Self(Arc::new(Vec::new()))
+    }
+}
+
+// this allows us to treat FileData as a slice of bytes, which is useful for the Read trait
+impl AsRef<[u8]> for FileData {
+    fn as_ref(&self) -> &[u8] {
+        &self.0
+    }
+}
+// impl Read for ReadableFile {
+//     fn read(&mut self, buf: &mut [u8]) -> io::Result<usize> {
+//         self.0.read(buf)
+//     }
+// }
+//
+// impl Seek for ReadableFile {
+//     fn seek(&mut self, pos: io::SeekFrom) -> io::Result<u64> {
+//         self.0.seek(pos)
+//     }
+// }
+
+impl FileSystem for MemoryFileSystem {
+    fn create_dir_all(&self, path: impl AsRef<Path>) -> Result<(), io::Error> {
+        let mut root = self.root.write().unwrap();
+        let path = path.as_ref();
+
+        // make sure all directories in the path exist
+        let mut dir: &mut Directory = &mut root;
+        for component in path.components() {
+            let name = component.as_os_str().to_string_lossy().to_string();
+            dir = dir.subdirs.entry(name).or_insert_with(Directory::new);
+        }
+        Ok(())
+    }
+
+    fn list(&self, path: impl AsRef<Path>) -> Result<Vec<PathBuf>, io::Error> {
+        let root = self.root.read().unwrap();
+        let path = path.as_ref();
+
+        // find the directory
+        let mut dir: &Directory = &root;
+        for component in path.components() {
+            let name = component.as_os_str().to_string_lossy().to_string();
+            dir = match dir.subdirs.get(&name) {
+                Some(subdir) => subdir,
+                None => {
+                    return Err(io::Error::new(
+                        io::ErrorKind::NotFound,
+                        "directory not found",
+                    ))
+                }
+            };
+        }
+
+        // list the contents
+        let mut entries = vec![];
+        for name in dir.subdirs.keys() {
+            entries.push(path.join(name));
+        }
+        for name in dir.files.keys() {
+            entries.push(path.join(name));
+        }
+        Ok(entries)
+    }
+
+    fn exists(&self, path: impl AsRef<Path>) -> bool {
+        let root = self.root.read().unwrap();
+        let path = path.as_ref();
+
+        let Some(parent) = path.parent() else {
+            return false;
+        };
+
+        // find the directory
+        let mut dir: &Directory = &root;
+        for component in parent.components() {
+            let name = component.as_os_str().to_string_lossy().to_string();
+            dir = match dir.subdirs.get(&name) {
+                Some(subdir) => subdir,
+                None => return false,
+            };
+        }
+
+        // get file / directory name
+        let name = path.file_name().unwrap().to_string_lossy().to_string();
+
+        // check if it exists as a directory or file
+        dir.subdirs.contains_key(&name) || dir.files.contains_key(&name)
+    }
+
+    fn open(&self, path: impl AsRef<Path>) -> Result<impl Read + Seek + Send + 'static, io::Error> {
+        let root = self.root.read().unwrap();
+        let path = path.as_ref();
+
+        let Some(parent) = path.parent() else {
+            return Err(io::Error::new(
+                io::ErrorKind::NotFound,
+                "parent directory not found",
+            ));
+        };
+
+        // find the directory
+        let mut dir: &Directory = &root;
+        for component in parent.components() {
+            let name = component.as_os_str().to_string_lossy().to_string();
+            dir = match dir.subdirs.get(&name) {
+                Some(subdir) => subdir,
+                None => {
+                    return Err(io::Error::new(
+                        io::ErrorKind::NotFound,
+                        "parent directory not found",
+                    ))
+                }
+            };
+        }
+
+        // get file name
+        let name = path.file_name().unwrap().to_string_lossy().to_string();
+
+        // get the file entry
+        let file = match dir.files.get(&name) {
+            Some(file) => file,
+            None => return Err(io::Error::new(io::ErrorKind::NotFound, "file not found")),
+        };
+
+        // create a reader by cloning the Arc
+        let data = file.data.read().unwrap().clone();
+        Ok(io::Cursor::new(data))
+    }
+
+    fn create(&self, path: impl AsRef<Path>) -> Result<impl Write + Seek, io::Error> {
+        let mut root = self.root.write().unwrap();
+        let path = path.as_ref();
+
+        let Some(parent) = path.parent() else {
+            return Err(io::Error::new(
+                io::ErrorKind::NotFound,
+                "parent directory not found",
+            ));
+        };
+
+        // find the parent directory
+        let mut dir: &mut Directory = &mut root;
+        for component in parent.components() {
+            let name = component.as_os_str().to_string_lossy().to_string();
+            dir = match dir.subdirs.get_mut(&name) {
+                Some(subdir) => subdir,
+                None => {
+                    return Err(io::Error::new(
+                        io::ErrorKind::NotFound,
+                        "parent directory not found",
+                    ))
+                }
+            };
+        }
+
+        // get file name
+        let name = path.file_name().unwrap().to_string_lossy().to_string();
+
+        // open or create new file
+        let file = dir.files.entry(name).or_insert(FileEntry::new());
+
+        // now we replace the arc with a new one which we will write to. This way existing readers
+        // will continue to read the old data, while we start filling up some new data)
+        let writer = WritableFile {
+            data: io::Cursor::new(Vec::new()),
+            data_link: file.data.clone(), // linked to the place where the data is stored
+        };
+        Ok(writer)
+    }
+
+    fn read_to_string(&self, path: impl AsRef<Path>) -> Result<String, io::Error> {
+        let root = self.root.read().unwrap();
+        let path = path.as_ref();
+
+        let Some(parent) = path.parent() else {
+            return Err(io::Error::new(
+                io::ErrorKind::NotFound,
+                "parent directory not found",
+            ));
+        };
+
+        // find the directory
+        let mut dir: &Directory = &root;
+        for component in parent.components() {
+            let name = component.as_os_str().to_string_lossy().to_string();
+            dir = match dir.subdirs.get(&name) {
+                Some(subdir) => subdir,
+                None => {
+                    return Err(io::Error::new(
+                        io::ErrorKind::NotFound,
+                        "parent directory not found",
+                    ))
+                }
+            };
+        }
+
+        // get file name
+        let name = path.file_name().unwrap().to_string_lossy().to_string();
+
+        // get the file entry
+        let file = match dir.files.get(&name) {
+            Some(file) => file,
+            None => return Err(io::Error::new(io::ErrorKind::NotFound, "file not found")),
+        };
+
+        // create a reader by cloning the Arc
+        let data = file.data.read().unwrap();
+
+        // convert to string lossily expecting all data to be valid utf8
+        let str = str::from_utf8(&data.0).map_err(|e| {
+            io::Error::new(io::ErrorKind::InvalidInput, format!("invalid UTF-8: {e} "))
+        })?;
+
+        Ok(str.to_string())
+    }
+
+    fn remove_file(&self, path: impl AsRef<Path>) -> Result<(), io::Error> {
+        let mut root = self.root.write().unwrap();
+        let path = path.as_ref();
+
+        let Some(parent) = path.parent() else {
+            return Err(io::Error::new(
+                io::ErrorKind::NotFound,
+                "parent directory not found",
+            ));
+        };
+
+        // find the directory
+        let mut dir: &mut Directory = &mut root;
+        for component in parent.components() {
+            let name = component.as_os_str().to_string_lossy().to_string();
+            dir = match dir.subdirs.get_mut(&name) {
+                Some(subdir) => subdir,
+                None => {
+                    return Err(io::Error::new(
+                        io::ErrorKind::NotFound,
+                        "parent directory not found",
+                    ))
+                }
+            };
+        }
+
+        // get file name
+        let name = path.file_name().unwrap().to_string_lossy().to_string();
+
+        // remove the file
+        dir.files
+            .remove(&name)
+            .ok_or_else(|| io::Error::new(io::ErrorKind::NotFound, "file not found"))?;
+
+        Ok(())
+    }
+
+    fn file_size(&self, path: impl AsRef<Path>) -> Result<u64, io::Error> {
+        let root = self.root.read().unwrap();
+        let path = path.as_ref();
+
+        let Some(parent) = path.parent() else {
+            return Err(io::Error::new(
+                io::ErrorKind::NotFound,
+                "parent directory not found",
+            ));
+        };
+
+        // find the directory
+        let mut dir: &Directory = &root;
+        for component in parent.components() {
+            let name = component.as_os_str().to_string_lossy().to_string();
+            dir = match dir.subdirs.get(&name) {
+                Some(subdir) => subdir,
+                None => {
+                    return Err(io::Error::new(
+                        io::ErrorKind::NotFound,
+                        "parent directory not found",
+                    ))
+                }
+            };
+        }
+
+        // get file name
+        let name = path.file_name().unwrap().to_string_lossy().to_string();
+
+        // get the file entry
+        let file = match dir.files.get(&name) {
+            Some(file) => file,
+            None => return Err(io::Error::new(io::ErrorKind::NotFound, "file not found")),
+        };
+
+        let data = file.data.read().expect("file data lock poisoned");
+        Ok(data.0.len() as u64)
+    }
+
+    fn copy(&self, from: impl AsRef<Path>, to: impl AsRef<Path>) -> Result<(), io::Error> {
+        let mut root = self.root.write().unwrap();
+        let from = from.as_ref();
+        let to = to.as_ref();
+
+        let Some(from_parent) = from.parent() else {
+            return Err(io::Error::new(
+                io::ErrorKind::NotFound,
+                "from parent directory not found",
+            ));
+        };
+
+        let Some(to_parent) = to.parent() else {
+            return Err(io::Error::new(
+                io::ErrorKind::NotFound,
+                "to parent directory not found",
+            ));
+        };
+
+        // find the from directory
+        let mut from_dir: &Directory = &root;
+        for component in from_parent.components() {
+            let name = component.as_os_str().to_string_lossy().to_string();
+            from_dir = match from_dir.subdirs.get(&name) {
+                Some(subdir) => subdir,
+                None => {
+                    return Err(io::Error::new(
+                        io::ErrorKind::NotFound,
+                        "from parent directory not found",
+                    ))
+                }
+            };
+        }
+        // get the from file entry and clone the data
+        let from_name = from.file_name().unwrap().to_string_lossy().to_string();
+        let from_file = match from_dir.files.get(&from_name) {
+            Some(file) => file,
+            None => return Err(io::Error::new(io::ErrorKind::NotFound, "file not found")),
+        };
+        let from_data = from_file
+            .data
+            .read()
+            .expect("file data lock poisoned")
+            .clone();
+
+        // find the to directory
+        let mut to_dir: &mut Directory = &mut root;
+        for component in to_parent.components() {
+            let name = component.as_os_str().to_string_lossy().to_string();
+            to_dir = match to_dir.subdirs.get_mut(&name) {
+                Some(subdir) => subdir,
+                None => {
+                    return Err(io::Error::new(
+                        io::ErrorKind::NotFound,
+                        "from parent directory not found",
+                    ))
+                }
+            };
+        }
+
+        // get file names
+        let to_name = to.file_name().unwrap().to_string_lossy().to_string();
+        let to_file = to_dir.files.entry(to_name).or_insert(FileEntry::new());
+        // copy the data
+        let mut to_data = to_file.data.write().expect("file data lock poisoned");
+        *to_data = from_data;
+
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod test {
+
+    use super::*;
+
+    #[test]
+    fn test_write_read_to_string_root() {
+        let fs = super::MemoryFileSystem::new();
+        let path = "test.txt";
+        let content = "Hello, World!";
+
+        fs.create(path)
+            .unwrap()
+            .write_all(content.as_bytes())
+            .unwrap();
+
+        let read = fs.read_to_string(path).unwrap();
+
+        assert_eq!(read, content);
+    }
+
+    #[test]
+    fn test_write_read_to_string_subdir() {
+        let fs = super::MemoryFileSystem::new();
+        let folder = Path::new("folder");
+        fs.create_dir_all(folder).unwrap();
+        let path = folder.join("test.txt");
+        let content = "Hello, World!";
+
+        fs.create(&path)
+            .unwrap()
+            .write_all(content.as_bytes())
+            .unwrap();
+
+        let read = fs.read_to_string(path).unwrap();
+
+        assert_eq!(read, content);
+    }
+}

--- a/src/io/fs/mod.rs
+++ b/src/io/fs/mod.rs
@@ -31,6 +31,18 @@ pub trait FileSystem {
 
     /// Copy a file.
     fn copy(&self, from: impl AsRef<Path>, to: impl AsRef<Path>) -> Result<(), io::Error>;
+
+    /// Write an image with the desired format.
+    fn read_image(
+        &self,
+        path: impl AsRef<Path>,
+    ) -> Result<image::DynamicImage, image::error::ImageError> {
+        image::ImageReader::new(std::io::BufReader::new(
+            self.open(path).expect("Could not open file"),
+        ))
+        .with_guessed_format()?
+        .decode()
+    }
 }
 
 /// [`FileSystem`] implementation for the local file system.

--- a/src/io/fs/mod.rs
+++ b/src/io/fs/mod.rs
@@ -1,6 +1,6 @@
 use std::{
     io::{self, Read, Seek, Write},
-    path::Path,
+    path::{Path, PathBuf},
 };
 
 /// Trait for file system operations.
@@ -9,7 +9,7 @@ pub trait FileSystem {
     fn create_dir_all(&self, path: impl AsRef<Path>) -> Result<(), io::Error>;
 
     /// List the contents of a directory.
-    fn list(&self, path: impl AsRef<Path>) -> Result<Vec<String>, io::Error>;
+    fn list(&self, path: impl AsRef<Path>) -> Result<Vec<PathBuf>, io::Error>;
 
     /// Check if a file exists.
     fn exists(&self, path: impl AsRef<Path>) -> bool;
@@ -42,11 +42,12 @@ impl FileSystem for LocalFileSystem {
         std::fs::create_dir_all(path)
     }
 
-    fn list(&self, path: impl AsRef<Path>) -> Result<Vec<String>, io::Error> {
+    fn list(&self, path: impl AsRef<Path>) -> Result<Vec<PathBuf>, io::Error> {
+        let path = path.as_ref();
         let mut entries = vec![];
         for entry in std::fs::read_dir(path)? {
             let entry = entry?;
-            entries.push(entry.file_name().to_string_lossy().to_string());
+            entries.push(path.join(entry.file_name()));
         }
         Ok(entries)
     }

--- a/src/io/fs/mod.rs
+++ b/src/io/fs/mod.rs
@@ -3,6 +3,8 @@ use std::{
     path::{Path, PathBuf},
 };
 
+pub mod local;
+
 /// Trait for file system operations.
 pub trait FileSystem {
     /// Create a new directory.
@@ -42,55 +44,5 @@ pub trait FileSystem {
         ))
         .with_guessed_format()?
         .decode()
-    }
-}
-
-/// [`FileSystem`] implementation for the local file system.
-#[derive(Clone)]
-pub struct LocalFileSystem;
-
-impl FileSystem for LocalFileSystem {
-    fn create_dir_all(&self, path: impl AsRef<Path>) -> Result<(), io::Error> {
-        std::fs::create_dir_all(path)
-    }
-
-    fn list(&self, path: impl AsRef<Path>) -> Result<Vec<PathBuf>, io::Error> {
-        let path = path.as_ref();
-        let mut entries = vec![];
-        for entry in std::fs::read_dir(path)? {
-            let entry = entry?;
-            entries.push(path.join(entry.file_name()));
-        }
-        Ok(entries)
-    }
-
-    fn exists(&self, path: impl AsRef<Path>) -> bool {
-        path.as_ref().exists()
-    }
-
-    fn read_to_string(&self, path: impl AsRef<Path>) -> Result<String, io::Error> {
-        std::fs::read_to_string(path)
-    }
-
-    fn open(&self, path: impl AsRef<Path>) -> Result<impl Read + Seek, io::Error> {
-        std::fs::File::open(path)
-    }
-
-    fn create(&self, path: impl AsRef<Path>) -> Result<impl Write + Seek, io::Error> {
-        std::fs::File::create(path)
-    }
-
-    fn remove_file(&self, path: impl AsRef<Path>) -> Result<(), io::Error> {
-        std::fs::remove_file(path)
-    }
-
-    fn file_size(&self, path: impl AsRef<Path>) -> Result<u64, io::Error> {
-        let metadata = std::fs::metadata(path)?;
-        Ok(metadata.len())
-    }
-
-    fn copy(&self, from: impl AsRef<Path>, to: impl AsRef<Path>) -> Result<(), io::Error> {
-        std::fs::copy(from, to)?;
-        Ok(())
     }
 }

--- a/src/io/fs/mod.rs
+++ b/src/io/fs/mod.rs
@@ -1,0 +1,67 @@
+use std::{
+    io::{self, Read, Seek, Write},
+    path::Path,
+};
+
+/// Trait for file system operations.
+pub trait FileSystem {
+    /// Create a new directory.
+    fn mkdir(&self, path: &Path) -> Result<(), io::Error>;
+
+    /// List the contents of a directory.
+    fn list(&self, path: &Path) -> Result<Vec<String>, io::Error>;
+
+    /// Check if a file exists.
+    fn exists(&self, path: &Path) -> Result<bool, io::Error>;
+
+    /// Open a file for reading.
+    fn read(&self, path: &Path) -> Result<impl Read + Seek, io::Error>;
+
+    /// Open a file for writing.
+    fn write(&self, path: &Path) -> Result<impl Write, io::Error>;
+
+    /// Remove a file.
+    fn remove(&self, path: &Path) -> Result<(), io::Error>;
+
+    /// Copy a file.
+    fn copy(&self, from: &Path, to: &Path) -> Result<(), io::Error>;
+}
+
+/// [`FileSystem`] implementation for the local file system.
+pub struct LocalFileSystem;
+
+impl FileSystem for LocalFileSystem {
+    fn mkdir(&self, path: &Path) -> Result<(), io::Error> {
+        std::fs::create_dir_all(path)
+    }
+
+    fn list(&self, path: &Path) -> Result<Vec<String>, io::Error> {
+        let mut entries = vec![];
+        for entry in std::fs::read_dir(path)? {
+            let entry = entry?;
+            entries.push(entry.file_name().to_string_lossy().to_string());
+        }
+        Ok(entries)
+    }
+
+    fn exists(&self, path: &Path) -> Result<bool, io::Error> {
+        Ok(path.exists())
+    }
+
+    fn read(&self, path: &Path) -> Result<impl Read + Seek, io::Error> {
+        std::fs::File::open(path)
+    }
+
+    fn write(&self, path: &Path) -> Result<impl Write, io::Error> {
+        std::fs::File::create(path)
+    }
+
+    fn remove(&self, path: &Path) -> Result<(), io::Error> {
+        std::fs::remove_file(path)
+    }
+
+    fn copy(&self, from: &Path, to: &Path) -> Result<(), io::Error> {
+        std::fs::copy(from, to)?;
+        Ok(())
+    }
+}

--- a/src/io/fs/mod.rs
+++ b/src/io/fs/mod.rs
@@ -6,7 +6,7 @@ use std::{
 pub mod local;
 
 /// Trait for file system operations.
-pub trait FileSystem {
+pub trait FileSystem: std::fmt::Debug {
     /// Create a new directory.
     fn create_dir_all(&self, path: impl AsRef<Path>) -> Result<(), io::Error>;
 
@@ -17,7 +17,7 @@ pub trait FileSystem {
     fn exists(&self, path: impl AsRef<Path>) -> bool;
 
     /// Open a file for reading.
-    fn open(&self, path: impl AsRef<Path>) -> Result<impl Read + Seek, io::Error>;
+    fn open(&self, path: impl AsRef<Path>) -> Result<impl Read + Seek + Send + 'static, io::Error>;
 
     /// Open a file for writing.
     fn create(&self, path: impl AsRef<Path>) -> Result<impl Write + Seek, io::Error>;

--- a/src/io/fs/mod.rs
+++ b/src/io/fs/mod.rs
@@ -4,6 +4,7 @@ use std::{
 };
 
 pub mod local;
+pub mod memory;
 
 /// Trait for file system operations.
 pub trait FileSystem: std::fmt::Debug {

--- a/src/io/fs/mod.rs
+++ b/src/io/fs/mod.rs
@@ -6,36 +6,40 @@ use std::{
 /// Trait for file system operations.
 pub trait FileSystem {
     /// Create a new directory.
-    fn mkdir(&self, path: &Path) -> Result<(), io::Error>;
+    fn create_dir_all(&self, path: impl AsRef<Path>) -> Result<(), io::Error>;
 
     /// List the contents of a directory.
-    fn list(&self, path: &Path) -> Result<Vec<String>, io::Error>;
+    fn list(&self, path: impl AsRef<Path>) -> Result<Vec<String>, io::Error>;
 
     /// Check if a file exists.
-    fn exists(&self, path: &Path) -> Result<bool, io::Error>;
+    fn exists(&self, path: impl AsRef<Path>) -> bool;
 
     /// Open a file for reading.
-    fn read(&self, path: &Path) -> Result<impl Read + Seek, io::Error>;
+    fn open(&self, path: impl AsRef<Path>) -> Result<impl Read + Seek, io::Error>;
 
     /// Open a file for writing.
-    fn write(&self, path: &Path) -> Result<impl Write, io::Error>;
+    fn create(&self, path: impl AsRef<Path>) -> Result<impl Write + Seek, io::Error>;
+
+    /// Read a file into a String.
+    fn read_to_string(&self, path: impl AsRef<Path>) -> Result<String, io::Error>;
 
     /// Remove a file.
-    fn remove(&self, path: &Path) -> Result<(), io::Error>;
+    fn remove_file(&self, path: impl AsRef<Path>) -> Result<(), io::Error>;
 
     /// Copy a file.
-    fn copy(&self, from: &Path, to: &Path) -> Result<(), io::Error>;
+    fn copy(&self, from: impl AsRef<Path>, to: impl AsRef<Path>) -> Result<(), io::Error>;
 }
 
 /// [`FileSystem`] implementation for the local file system.
+#[derive(Clone)]
 pub struct LocalFileSystem;
 
 impl FileSystem for LocalFileSystem {
-    fn mkdir(&self, path: &Path) -> Result<(), io::Error> {
+    fn create_dir_all(&self, path: impl AsRef<Path>) -> Result<(), io::Error> {
         std::fs::create_dir_all(path)
     }
 
-    fn list(&self, path: &Path) -> Result<Vec<String>, io::Error> {
+    fn list(&self, path: impl AsRef<Path>) -> Result<Vec<String>, io::Error> {
         let mut entries = vec![];
         for entry in std::fs::read_dir(path)? {
             let entry = entry?;
@@ -44,23 +48,27 @@ impl FileSystem for LocalFileSystem {
         Ok(entries)
     }
 
-    fn exists(&self, path: &Path) -> Result<bool, io::Error> {
-        Ok(path.exists())
+    fn exists(&self, path: impl AsRef<Path>) -> bool {
+        path.as_ref().exists()
     }
 
-    fn read(&self, path: &Path) -> Result<impl Read + Seek, io::Error> {
+    fn read_to_string(&self, path: impl AsRef<Path>) -> Result<String, io::Error> {
+        std::fs::read_to_string(path)
+    }
+
+    fn open(&self, path: impl AsRef<Path>) -> Result<impl Read + Seek, io::Error> {
         std::fs::File::open(path)
     }
 
-    fn write(&self, path: &Path) -> Result<impl Write, io::Error> {
+    fn create(&self, path: impl AsRef<Path>) -> Result<impl Write + Seek, io::Error> {
         std::fs::File::create(path)
     }
 
-    fn remove(&self, path: &Path) -> Result<(), io::Error> {
+    fn remove_file(&self, path: impl AsRef<Path>) -> Result<(), io::Error> {
         std::fs::remove_file(path)
     }
 
-    fn copy(&self, from: &Path, to: &Path) -> Result<(), io::Error> {
+    fn copy(&self, from: impl AsRef<Path>, to: impl AsRef<Path>) -> Result<(), io::Error> {
         std::fs::copy(from, to)?;
         Ok(())
     }

--- a/src/io/fs/mod.rs
+++ b/src/io/fs/mod.rs
@@ -26,6 +26,9 @@ pub trait FileSystem {
     /// Remove a file.
     fn remove_file(&self, path: impl AsRef<Path>) -> Result<(), io::Error>;
 
+    /// Get the size of a file in bytes.
+    fn file_size(&self, path: impl AsRef<Path>) -> Result<u64, io::Error>;
+
     /// Copy a file.
     fn copy(&self, from: impl AsRef<Path>, to: impl AsRef<Path>) -> Result<(), io::Error>;
 }
@@ -66,6 +69,11 @@ impl FileSystem for LocalFileSystem {
 
     fn remove_file(&self, path: impl AsRef<Path>) -> Result<(), io::Error> {
         std::fs::remove_file(path)
+    }
+
+    fn file_size(&self, path: impl AsRef<Path>) -> Result<u64, io::Error> {
+        let metadata = std::fs::metadata(path)?;
+        Ok(metadata.len())
     }
 
     fn copy(&self, from: impl AsRef<Path>, to: impl AsRef<Path>) -> Result<(), io::Error> {

--- a/src/io/heightmap.rs
+++ b/src/io/heightmap.rs
@@ -1,6 +1,6 @@
 use crate::vec2d::Vec2D;
 
-use super::bytes::FromToBytes;
+use super::{bytes::FromToBytes, fs::FileSystem};
 
 /// Simple container of a rectangular heightmap
 #[derive(Debug, Clone, PartialEq)]
@@ -46,15 +46,22 @@ impl HeightMap {
 
 impl HeightMap {
     /// Helper for easily reading a HeightMap from a file
-    pub fn from_file<P: AsRef<std::path::Path>>(path: P) -> std::io::Result<Self> {
-        let file = std::fs::File::open(path)?;
+    pub fn from_file<P: AsRef<std::path::Path>>(
+        fs: &impl FileSystem,
+        path: P,
+    ) -> std::io::Result<Self> {
+        let file = fs.open(path)?;
         let mut reader = std::io::BufReader::new(file);
         HeightMap::from_bytes(&mut reader)
     }
 
     /// Helper for easily writing a HeightMap to a file
-    pub fn to_file<P: AsRef<std::path::Path>>(&self, path: P) -> std::io::Result<()> {
-        let file = std::fs::File::create(path)?;
+    pub fn to_file<P: AsRef<std::path::Path>>(
+        &self,
+        fs: &impl FileSystem,
+        path: P,
+    ) -> std::io::Result<()> {
+        let file = fs.create(path)?;
         let mut writer = std::io::BufWriter::new(file);
         self.to_bytes(&mut writer)
     }

--- a/src/io/mod.rs
+++ b/src/io/mod.rs
@@ -7,6 +7,7 @@ use std::{
 use heightmap::HeightMap;
 
 pub mod bytes;
+pub mod fs;
 pub mod heightmap;
 pub mod xyz;
 

--- a/src/io/mod.rs
+++ b/src/io/mod.rs
@@ -1,5 +1,4 @@
 use std::{
-    fs::File,
     io::{BufReader, BufWriter, Write},
     path::Path,
 };
@@ -16,7 +15,7 @@ pub mod xyz;
 pub fn internal2xyz(fs: &impl FileSystem, input: &str, output: &str) -> std::io::Result<()> {
     if input.ends_with(".xyz.bin") {
         let mut reader = xyz::XyzInternalReader::new(BufReader::new(fs.open(Path::new(input))?))?;
-        let mut writer = BufWriter::new(File::create(output)?);
+        let mut writer = BufWriter::new(fs.create(output)?);
 
         while let Some(record) = reader.next()? {
             writeln!(
@@ -31,8 +30,8 @@ pub fn internal2xyz(fs: &impl FileSystem, input: &str, output: &str) -> std::io:
             )?;
         }
     } else if input.ends_with(".hmap") {
-        let hmap = HeightMap::from_file(input)?;
-        let mut writer = BufWriter::new(File::create(output)?);
+        let hmap = HeightMap::from_file(fs, input)?;
+        let mut writer = BufWriter::new(fs.create(output)?);
 
         for (x, y, h) in hmap.iter() {
             writeln!(writer, "{} {} {}", x, y, h)?;

--- a/src/io/mod.rs
+++ b/src/io/mod.rs
@@ -1,9 +1,10 @@
 use std::{
     fs::File,
-    io::{BufWriter, Write},
+    io::{BufReader, BufWriter, Write},
     path::Path,
 };
 
+use fs::FileSystem;
 use heightmap::HeightMap;
 
 pub mod bytes;
@@ -12,9 +13,9 @@ pub mod heightmap;
 pub mod xyz;
 
 /// Helper function to convert an internal xyz file to a regular xyz file.
-pub fn internal2xyz(input: &str, output: &str) -> std::io::Result<()> {
+pub fn internal2xyz(fs: &impl FileSystem, input: &str, output: &str) -> std::io::Result<()> {
     if input.ends_with(".xyz.bin") {
-        let mut reader = xyz::XyzInternalReader::open(Path::new(input))?;
+        let mut reader = xyz::XyzInternalReader::new(BufReader::new(fs.open(Path::new(input))?))?;
         let mut writer = BufWriter::new(File::create(output)?);
 
         while let Some(record) = reader.next()? {

--- a/src/io/xyz.rs
+++ b/src/io/xyz.rs
@@ -1,8 +1,6 @@
 use crate::io::bytes::FromToBytes;
 use std::{
-    fs::File,
-    io::{BufReader, BufWriter, Read, Seek, Write},
-    path::Path,
+    io::{Read, Seek, Write},
     time::Instant,
 };
 
@@ -63,14 +61,6 @@ pub struct XyzInternalWriter<W: Write + Seek> {
     records_written: u64,
     // for stats
     start: Option<Instant>,
-}
-
-impl XyzInternalWriter<BufWriter<File>> {
-    pub fn create(path: &Path) -> std::io::Result<Self> {
-        debug!("Writing records to {:?}", path);
-        let file = File::create(path)?;
-        Ok(Self::new(BufWriter::new(file)))
-    }
 }
 
 impl<W: Write + Seek> XyzInternalWriter<W> {
@@ -144,14 +134,6 @@ pub struct XyzInternalReader<R: Read> {
     records_read: u64,
     // for stats
     start: Option<Instant>,
-}
-
-impl XyzInternalReader<BufReader<File>> {
-    pub fn open(path: &Path) -> std::io::Result<Self> {
-        debug!("Reading records from: {:?}", path);
-        let file = File::open(path)?;
-        Self::new(BufReader::new(file))
-    }
 }
 
 impl<R: Read> XyzInternalReader<R> {

--- a/src/main.rs
+++ b/src/main.rs
@@ -337,37 +337,48 @@ fn main() {
             norender = args[1].clone() == "norender";
         }
 
-        // TEMP: use MemoryFileSystem for testing
-        let fs = pullauta::io::fs::memory::MemoryFileSystem::new();
+        if config.experimental_use_in_memory_fs {
+            let fs = pullauta::io::fs::memory::MemoryFileSystem::new();
 
-        debug!("Copying input file into memory fs: {}", command);
-        // copy the input file into the memory file system
-        fs.load_from_disk(Path::new(&command), Path::new("input.laz"))
-            .expect("Could not copy input file into memory fs");
+            debug!("Copying input file into memory fs: {}", command);
+            // copy the input file into the memory file system
+            fs.load_from_disk(Path::new(&command), Path::new("input.laz"))
+                .expect("Could not copy input file into memory fs");
 
-        debug!("Done");
+            debug!("Done");
 
-        pullauta::process::process_tile(
-            &fs,
-            &config,
-            &thread,
-            &tmpfolder,
-            // Path::new(&command),
-            Path::new("input.laz"),
-            norender,
-        )
-        .unwrap();
+            pullauta::process::process_tile(
+                &fs,
+                &config,
+                &thread,
+                &tmpfolder,
+                // Path::new(&command),
+                Path::new("input.laz"),
+                norender,
+            )
+            .unwrap();
 
-        debug!("{:#?}", fs);
+            debug!("{:#?}", fs);
 
-        // now write the output files to disk
-        fn copy(fs: &MemoryFileSystem, name: &str) {
-            if fs.exists(name) {
-                fs.save_to_disk(name, name)
-                    .expect("Could not copy from memory fs to disk");
+            // now write the output files to disk
+            fn copy(fs: &MemoryFileSystem, name: &str) {
+                if fs.exists(name) {
+                    fs.save_to_disk(name, name)
+                        .expect("Could not copy from memory fs to disk");
+                }
             }
+            copy(&fs, "pullautus.png");
+            copy(&fs, "pullautus_depr.png");
+        } else {
+            pullauta::process::process_tile(
+                &fs,
+                &config,
+                &thread,
+                &tmpfolder,
+                Path::new(&command),
+                norender,
+            )
+            .unwrap();
         }
-        copy(&fs, "pullautus.png");
-        copy(&fs, "pullautus_depr.png");
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -33,7 +33,7 @@ fn main() {
     let config =
         Arc::new(Config::load_or_create_default().expect("Could not open or create config file"));
 
-    let fs = pullauta::io::fs::LocalFileSystem;
+    let fs = pullauta::io::fs::local::LocalFileSystem;
 
     let mut args: Vec<String> = env::args().collect();
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -262,7 +262,7 @@ fn main() {
         let hmap = pullauta::contours::xyz2heightmap(&fs, &config, &tmpfolder, &xyzfilein).unwrap();
 
         if xyzfileout != "null" && !xyzfileout.is_empty() {
-            hmap.to_file(xyzfileout).unwrap();
+            hmap.to_file(&fs, xyzfileout).unwrap();
         }
 
         pullauta::contours::heightmap2contours(&fs, &tmpfolder, cinterval, &hmap, &dxffile)

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,5 +1,6 @@
 use log::info;
 use pullauta::config::Config;
+use pullauta::io::fs::FileSystem;
 use std::env;
 use std::fs;
 use std::path::Path;
@@ -71,7 +72,7 @@ fn main() {
     let pnorthlinesangle = config.pnorthlinesangle;
     let pnorthlineswidth = config.pnorthlineswidth;
 
-    if command.is_empty() && tmpfolder.join("vegetation.png").exists() && !batch {
+    if command.is_empty() && fs.exists(tmpfolder.join("vegetation.png")) && !batch {
         info!("Rendering png map with depressions");
         pullauta::render::render(
             &fs,

--- a/src/main.rs
+++ b/src/main.rs
@@ -321,7 +321,7 @@ fn main() {
 
             // copy the output files back to disk
             for path in fs.list(&config.batchoutfolder).unwrap() {
-                println!("Copying {} from memory fs to disk", path.display());
+                info!("Copying {} from memory fs to disk", path.display());
                 fs.save_to_disk(&path, &path).unwrap();
             }
         } else {
@@ -393,11 +393,10 @@ fn main() {
             )
             .unwrap();
 
-            debug!("{:#?}", fs);
-
             // now write the output files to disk
             fn copy(fs: &MemoryFileSystem, name: &str) {
                 if fs.exists(name) {
+                    info!("Copying {} from memory fs to disk", name);
                     fs.save_to_disk(name, name)
                         .expect("Could not copy from memory fs to disk");
                 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -291,7 +291,11 @@ fn main() {
     let proc = config.processes;
     if command.is_empty() && batch && proc > 1 {
         // inner function to reduce code duplication
-        fn inner<F: FileSystem + Send + Clone + 'static>(fs: F, proc: u64, config: &Arc<Config>) {
+        fn launch_threads<F: FileSystem + Send + Clone + 'static>(
+            fs: F,
+            proc: u64,
+            config: &Arc<Config>,
+        ) {
             // do the processing
             let mut handles: Vec<thread::JoinHandle<()>> = Vec::with_capacity((proc + 1) as usize);
             for i in 0..proc {
@@ -321,7 +325,7 @@ fn main() {
                 fs.load_from_disk(&path, &path).unwrap();
             }
 
-            inner(fs.clone(), proc, &config);
+            launch_threads(fs.clone(), proc, &config);
 
             // copy the output files back to disk
             std::fs::create_dir_all(&config.batchoutfolder).unwrap();
@@ -330,7 +334,7 @@ fn main() {
                 fs.save_to_disk(&path, &path).unwrap();
             }
         } else {
-            inner(fs, proc, &config);
+            launch_threads(fs, proc, &config);
         }
         return;
     }

--- a/src/main.rs
+++ b/src/main.rs
@@ -320,6 +320,7 @@ fn main() {
             }
 
             // copy the output files back to disk
+            std::fs::create_dir_all(&config.batchoutfolder).unwrap();
             for path in fs.list(&config.batchoutfolder).unwrap() {
                 info!("Copying {} from memory fs to disk", path.display());
                 fs.save_to_disk(&path, &path).unwrap();

--- a/src/merge.rs
+++ b/src/merge.rs
@@ -28,7 +28,8 @@ fn merge_png(
     for png in png_files.iter() {
         let filename = png.as_path().file_name().unwrap().to_str().unwrap();
         let full_filename = format!("{}/{}", batchoutfolder, filename);
-        let img = image::open(Path::new(&full_filename)).expect("Opening image failed");
+        let img = fs.read_image(&full_filename).expect("Opening image failed");
+
         let width = img.width() as f64;
         let height = img.height() as f64;
         let pgw = full_filename.replace(".png", ".pgw");
@@ -70,7 +71,7 @@ fn merge_png(
         let pgw = Path::new(&pgw);
         let filesize = fs.file_size(png).unwrap();
         if fs.exists(png) && fs.exists(pgw) && filesize > 0 {
-            let img = image::open(png).expect("Opening image failed");
+            let img = fs.read_image(png).expect("Opening image failed");
             let width = img.width() as f64;
             let height = img.height() as f64;
 
@@ -92,10 +93,22 @@ fn merge_png(
             );
         }
     }
-    im.save(Path::new(&format!("{}.jpg", outfilename)))
-        .expect("could not save output jpg");
-    im.save(Path::new(&format!("{}.png", outfilename)))
-        .expect("could not save output png");
+
+    im.write_to(
+        &mut fs
+            .create(format!("{}.jpg", outfilename))
+            .expect("could not save output jpg"),
+        image::ImageFormat::Jpeg,
+    )
+    .expect("could not save output jpg");
+
+    im.write_to(
+        &mut fs
+            .create(format!("{}.png", outfilename))
+            .expect("could not save output png"),
+        image::ImageFormat::Png,
+    )
+    .expect("could not save output Png");
 
     let tfw_file = fs
         .create(format!("{}.pgw", outfilename))

--- a/src/merge.rs
+++ b/src/merge.rs
@@ -127,9 +127,8 @@ pub fn pngmergevege(
     let batchoutfolder = &config.batchoutfolder;
 
     let mut png_files: Vec<PathBuf> = Vec::new();
-    for element in Path::new(batchoutfolder).read_dir().unwrap() {
-        let path = element.unwrap().path();
-        let filename = &path.as_path().file_name().unwrap().to_str().unwrap();
+    for path in fs.list(batchoutfolder).unwrap() {
+        let filename = path.file_name().unwrap().to_str().unwrap();
         if filename.ends_with("_vege.png") {
             png_files.push(path);
         }
@@ -151,9 +150,8 @@ pub fn pngmerge(
     let batchoutfolder = &config.batchoutfolder;
 
     let mut png_files: Vec<PathBuf> = Vec::new();
-    for element in Path::new(batchoutfolder).read_dir().unwrap() {
-        let path = element.unwrap().path();
-        let filename = &path.as_path().file_name().unwrap().to_str().unwrap();
+    for path in fs.list(batchoutfolder).unwrap() {
+        let filename = path.file_name().unwrap().to_str().unwrap();
         if filename.ends_with(".png")
             && !filename.ends_with("_undergrowth.png")
             && !filename.ends_with("_undergrowth_bit.png")
@@ -182,8 +180,7 @@ pub fn dxfmerge(fs: &impl FileSystem, config: &Config) -> Result<(), Box<dyn Err
     let batchoutfolder = &config.batchoutfolder;
 
     let mut dxf_files: Vec<PathBuf> = Vec::new();
-    for element in Path::new(batchoutfolder).read_dir().unwrap() {
-        let path = element.unwrap().path();
+    for path in fs.list(batchoutfolder).unwrap() {
         if let Some(extension) = path.extension() {
             if extension == "dxf" {
                 dxf_files.push(path);

--- a/src/merge.rs
+++ b/src/merge.rs
@@ -2,7 +2,6 @@ use image::{Rgb, RgbImage};
 use log::info;
 use rustc_hash::FxHashMap as HashMap;
 use std::error::Error;
-use std::fs::{self};
 use std::io::{BufReader, BufWriter, Write};
 use std::path::{Path, PathBuf};
 
@@ -33,8 +32,8 @@ fn merge_png(
         let width = img.width() as f64;
         let height = img.height() as f64;
         let pgw = full_filename.replace(".png", ".pgw");
-        if Path::new(&pgw).exists() {
-            let input = Path::new(&pgw);
+        let input = Path::new(&pgw);
+        if fs.exists(input) {
             let data = fs.read_to_string(input).expect("Can not read input file");
             let d: Vec<&str> = data.split('\n').collect();
             let tfw0 = d[0].trim().parse::<f64>().unwrap();
@@ -67,14 +66,15 @@ fn merge_png(
         let filename = png.as_path().file_name().unwrap().to_str().unwrap();
         let png = format!("{}/{}", batchoutfolder, filename);
         let pgw = png.replace(".png", ".pgw");
-        let filesize = Path::new(&png).metadata().unwrap().len();
-        if Path::new(&png).exists() && Path::new(&pgw).exists() && filesize > 0 {
-            let img = image::open(Path::new(&png)).expect("Opening image failed");
+        let png = Path::new(&png);
+        let pgw = Path::new(&pgw);
+        let filesize = fs.file_size(png).unwrap();
+        if fs.exists(png) && fs.exists(pgw) && filesize > 0 {
+            let img = image::open(png).expect("Opening image failed");
             let width = img.width() as f64;
             let height = img.height() as f64;
 
-            let input = Path::new(&pgw);
-            let data = fs.read_to_string(input).expect("Can not read input file");
+            let data = fs.read_to_string(pgw).expect("Can not read input file");
             let d: Vec<&str> = data.split('\n').collect();
             let tfw4 = d[4].trim().parse::<f64>().unwrap();
             let tfw5 = d[5].trim().parse::<f64>().unwrap();
@@ -111,7 +111,7 @@ fn merge_png(
     )
     .expect("Could not write to file");
     tfw_out.flush().expect("Cannot flush");
-    fs::copy(
+    fs.copy(
         Path::new(&format!("{}.pgw", outfilename)),
         Path::new(&format!("{}.jgw", outfilename)),
     )
@@ -210,9 +210,8 @@ pub fn dxfmerge(fs: &impl FileSystem, config: &Config) -> Result<(), Box<dyn Err
     for dx in dxf_files.iter() {
         let dxf = dx.as_path().file_name().unwrap().to_str().unwrap();
         let dxf_filename = format!("{}/{}", batchoutfolder, dxf);
-
-        if Path::new(&dxf_filename).exists() && dxf_filename.ends_with("contours.dxf") {
-            let input = Path::new(&dxf_filename);
+        let input = Path::new(&dxf_filename);
+        if fs.exists(input) && dxf_filename.ends_with("contours.dxf") {
             let data = fs.read_to_string(input).expect("Can not read input file");
             if data.contains("POLYLINE") {
                 let d: Vec<&str> = data.splitn(2, "POLYLINE").collect();
@@ -258,8 +257,8 @@ pub fn dxfmerge(fs: &impl FileSystem, config: &Config) -> Result<(), Box<dyn Err
     for dx in dxf_files.iter() {
         let dxf = dx.as_path().file_name().unwrap().to_str().unwrap();
         let dxf_filename = format!("{}/{}", batchoutfolder, dxf);
-        if Path::new(&dxf_filename).exists() && dxf_filename.ends_with("_c2f.dxf") {
-            let input = Path::new(&dxf_filename);
+        let input = Path::new(&dxf_filename);
+        if fs.exists(input) && dxf_filename.ends_with("_c2f.dxf") {
             let data = fs.read_to_string(input).expect("Can not read input file");
             if data.contains("POLYLINE") {
                 let d: Vec<&str> = data.splitn(2, "POLYLINE").collect();
@@ -296,8 +295,8 @@ pub fn dxfmerge(fs: &impl FileSystem, config: &Config) -> Result<(), Box<dyn Err
     for dx in dxf_files.iter() {
         let dxf = dx.as_path().file_name().unwrap().to_str().unwrap();
         let dxf_filename = format!("{}/{}", batchoutfolder, dxf);
-        if Path::new(&dxf_filename).exists() && dxf_filename.ends_with("_c2g.dxf") {
-            let input = Path::new(&dxf_filename);
+        let input = Path::new(&dxf_filename);
+        if fs.exists(input) && dxf_filename.ends_with("_c2g.dxf") {
             let data = fs.read_to_string(input).expect("Can not read input file");
             if data.contains("POLYLINE") {
                 let d: Vec<&str> = data.splitn(2, "POLYLINE").collect();
@@ -340,8 +339,8 @@ pub fn dxfmerge(fs: &impl FileSystem, config: &Config) -> Result<(), Box<dyn Err
         for dx in dxf_files.iter() {
             let dxf = dx.as_path().file_name().unwrap().to_str().unwrap();
             let dxf_filename = format!("{}/{}", batchoutfolder, dxf);
-            if Path::new(&dxf_filename).exists() && dxf_filename.ends_with("_basemap.dxf") {
-                let input = Path::new(&dxf_filename);
+            let input = Path::new(&dxf_filename);
+            if fs.exists(input) && dxf_filename.ends_with("_basemap.dxf") {
                 let data = fs.read_to_string(input).expect("Can not read input file");
                 if data.contains("POLYLINE") {
                     let d: Vec<&str> = data.splitn(2, "POLYLINE").collect();
@@ -379,8 +378,8 @@ pub fn dxfmerge(fs: &impl FileSystem, config: &Config) -> Result<(), Box<dyn Err
     for dx in dxf_files.iter() {
         let dxf = dx.as_path().file_name().unwrap().to_str().unwrap();
         let dxf_filename = format!("{}/{}", batchoutfolder, dxf);
-        if Path::new(&dxf_filename).exists() && dxf_filename.ends_with("_c3g.dxf") {
-            let input = Path::new(&dxf_filename);
+        let input = Path::new(&dxf_filename);
+        if fs.exists(input) && dxf_filename.ends_with("_c3g.dxf") {
             let data = fs.read_to_string(input).expect("Can not read input file");
             if data.contains("POLYLINE") {
                 let d: Vec<&str> = data.splitn(2, "POLYLINE").collect();
@@ -417,8 +416,8 @@ pub fn dxfmerge(fs: &impl FileSystem, config: &Config) -> Result<(), Box<dyn Err
     for dx in dxf_files.iter() {
         let dxf = dx.as_path().file_name().unwrap().to_str().unwrap();
         let dxf_filename = format!("{}/{}", batchoutfolder, dxf);
-        if Path::new(&dxf_filename).exists() && dxf_filename.ends_with("_formlines.dxf") {
-            let input = Path::new(&dxf_filename);
+        let input = Path::new(&dxf_filename);
+        if fs.exists(input) && dxf_filename.ends_with("_formlines.dxf") {
             let data = fs.read_to_string(input).expect("Can not read input file");
             if data.contains("POLYLINE") {
                 let d: Vec<&str> = data.splitn(2, "POLYLINE").collect();
@@ -457,8 +456,8 @@ pub fn dxfmerge(fs: &impl FileSystem, config: &Config) -> Result<(), Box<dyn Err
     for dx in dxf_files.iter() {
         let dxf = dx.as_path().file_name().unwrap().to_str().unwrap();
         let dxf_filename = format!("{}/{}", batchoutfolder, dxf);
-        if Path::new(&dxf_filename).exists() && dxf_filename.ends_with("_dotknolls.dxf") {
-            let input = Path::new(&dxf_filename);
+        let input = Path::new(&dxf_filename);
+        if fs.exists(input) && dxf_filename.ends_with("_dotknolls.dxf") {
             let data = fs.read_to_string(input).expect("Can not read input file");
             if data.contains("POINT") {
                 let d: Vec<&str> = data.splitn(2, "POINT").collect();
@@ -497,8 +496,8 @@ pub fn dxfmerge(fs: &impl FileSystem, config: &Config) -> Result<(), Box<dyn Err
     for dx in dxf_files.iter() {
         let dxf = dx.as_path().file_name().unwrap().to_str().unwrap();
         let dxf_filename = format!("{}/{}", batchoutfolder, dxf);
-        if Path::new(&dxf_filename).exists() && dxf_filename.ends_with("_detected.dxf") {
-            let input = Path::new(&dxf_filename);
+        let input = Path::new(&dxf_filename);
+        if fs.exists(input) && dxf_filename.ends_with("_detected.dxf") {
             let data = fs.read_to_string(input).expect("Can not read input file");
             if data.contains("POLYLINE") {
                 let d: Vec<&str> = data.splitn(2, "POLYLINE").collect();

--- a/src/process.rs
+++ b/src/process.rs
@@ -183,7 +183,10 @@ pub fn process_tile(
         let mut rng = rand::thread_rng();
         let randdist = distributions::Bernoulli::new(thinfactor).unwrap();
 
-        let mut reader = Reader::from_path(input_file).expect("Unable to open reader");
+        let mut reader = Reader::new(BufReader::new(
+            fs.open(input_file).expect("Could not open file"),
+        ))
+        .expect("Could not create reader");
 
         debug!("Writing records to {:?}", &target_file);
         let mut writer = XyzInternalWriter::new(BufWriter::new(
@@ -451,7 +454,9 @@ pub fn batch_process(conf: &Config, fs: &impl FileSystem, thread: &String) {
                 && header.max_y > miny2
                 && header.min_y < maxy2
             {
-                let mut reader = Reader::from_path(laz_p).expect("Unable to open reader");
+                let mut reader =
+                    Reader::new(BufReader::new(fs.open(laz_p).expect("Could not open file")))
+                        .expect("Could not create reader");
                 for ptu in reader.points() {
                     let pt = ptu.unwrap();
                     if pt.x > minx2

--- a/src/process.rs
+++ b/src/process.rs
@@ -554,7 +554,8 @@ pub fn batch_process(conf: &Config, fs: &impl FileSystem, thread: &String) {
             )
             .expect("Could not copy file");
 
-            let orig_img = image::open(Path::new(&format!("pullautus{}.png", thread)))
+            let orig_img = fs
+                .read_image(format!("pullautus{}.png", thread))
                 .expect("Opening image failed");
             let mut img = RgbImage::from_pixel(
                 ((maxx - minx) * 600.0 / 254.0 / scalefactor + 2.0) as u32,
@@ -567,10 +568,17 @@ pub fn batch_process(conf: &Config, fs: &impl FileSystem, thread: &String) {
                 (-dx * 600.0 / 254.0 / scalefactor) as i64,
                 (-dy * 600.0 / 254.0 / scalefactor) as i64,
             );
-            img.save(Path::new(&format!("pullautus{}.png", thread)))
-                .expect("could not save output png");
 
-            let orig_img = image::open(Path::new(&format!("pullautus_depr{}.png", thread)))
+            img.write_to(
+                &mut fs
+                    .create(format!("pullautus{}.png", thread))
+                    .expect("could not save output png"),
+                image::ImageFormat::Png,
+            )
+            .expect("could not save output png");
+
+            let orig_img = fs
+                .read_image(format!("pullautus_depr{}.png", thread))
                 .expect("Opening image failed");
             let mut img = RgbImage::from_pixel(
                 ((maxx - minx) * 600.0 / 254.0 / scalefactor + 2.0) as u32,
@@ -583,27 +591,30 @@ pub fn batch_process(conf: &Config, fs: &impl FileSystem, thread: &String) {
                 (-dx * 600.0 / 254.0 / scalefactor) as i64,
                 (-dy * 600.0 / 254.0 / scalefactor) as i64,
             );
-            img.save(Path::new(&format!("pullautus_depr{}.png", thread)))
-                .expect("could not save output png");
 
+            img.write_to(
+                &mut fs
+                    .create(format!("pullautus_depr{}.png", thread))
+                    .expect("could not save output png"),
+                image::ImageFormat::Png,
+            )
+            .expect("could not save output png");
+
+            fs.copy(format!("pullautus{}.png", thread), &outfile)
+                .expect("Could not copy file to output folder");
             fs.copy(
-                Path::new(&format!("pullautus{}.png", thread)),
-                Path::new(&outfile),
+                format!("pullautus{}.pgw", thread),
+                format!("{}/{}.pgw", batchoutfolder, laz),
             )
             .expect("Could not copy file to output folder");
             fs.copy(
-                Path::new(&format!("pullautus{}.pgw", thread)),
-                Path::new(&format!("{}/{}.pgw", batchoutfolder, laz)),
+                format!("pullautus_depr{}.png", thread),
+                format!("{}/{}_depr.png", batchoutfolder, laz),
             )
             .expect("Could not copy file to output folder");
             fs.copy(
-                Path::new(&format!("pullautus_depr{}.png", thread)),
-                Path::new(&format!("{}/{}_depr.png", batchoutfolder, laz)),
-            )
-            .expect("Could not copy file to output folder");
-            fs.copy(
-                Path::new(&format!("pullautus_depr{}.pgw", thread)),
-                Path::new(&format!("{}/{}_depr.pgw", batchoutfolder, laz)),
+                format!("pullautus_depr{}.pgw", thread),
+                format!("{}/{}_depr.pgw", batchoutfolder, laz),
             )
             .expect("Could not copy file to output folder");
         }
@@ -690,10 +701,13 @@ pub fn batch_process(conf: &Config, fs: &impl FileSystem, thread: &String) {
                     (-dx * 600.0 / 254.0 / scalefactor) as i64,
                     (-dy * 600.0 / 254.0 / scalefactor) as i64,
                 );
-                img.save(Path::new(&format!(
-                    "{}/{}_undergrowth.png",
-                    batchoutfolder, laz
-                )))
+
+                img.write_to(
+                    &mut fs
+                        .create(format!("{}/{}_undergrowth.png", batchoutfolder, laz))
+                        .expect("could not save output png"),
+                    image::ImageFormat::Png,
+                )
                 .expect("could not save output png");
 
                 let mut orig_img_reader =
@@ -707,8 +721,14 @@ pub fn batch_process(conf: &Config, fs: &impl FileSystem, thread: &String) {
                     Rgb([255, 255, 255]),
                 );
                 image::imageops::overlay(&mut img, &orig_img.to_rgb8(), -dx as i64, -dy as i64);
-                img.save(Path::new(&format!("{}/{}_vege.png", batchoutfolder, laz)))
-                    .expect("could not save output png");
+
+                img.write_to(
+                    &mut fs
+                        .create(format!("{}/{}_vege.png", batchoutfolder, laz))
+                        .expect("could not save output png"),
+                    image::ImageFormat::Png,
+                )
+                .expect("could not save output png");
 
                 let pgw_file_out = fs
                     .create(format!("{}/{}_vege.pgw", batchoutfolder, laz))
@@ -743,10 +763,12 @@ pub fn batch_process(conf: &Config, fs: &impl FileSystem, thread: &String) {
                         -dx as i64,
                         -dy as i64,
                     );
-                    img.save(Path::new(&format!(
-                        "{}/{}_vege_bit.png",
-                        batchoutfolder, laz
-                    )))
+                    img.write_to(
+                        &mut fs
+                            .create(format!("{}/{}_vege_bit.png", batchoutfolder, laz))
+                            .expect("could not save output png"),
+                        image::ImageFormat::Png,
+                    )
                     .expect("could not save output png");
 
                     let mut orig_img_reader = image::ImageReader::open(Path::new(&format!(
@@ -767,21 +789,23 @@ pub fn batch_process(conf: &Config, fs: &impl FileSystem, thread: &String) {
                         -dx as i64,
                         -dy as i64,
                     );
-                    img.save(Path::new(&format!(
-                        "{}/{}_undergrowth_bit.png",
-                        batchoutfolder, laz
-                    )))
+                    img.write_to(
+                        &mut fs
+                            .create(format!("{}/{}_undergrowth_bit.png", batchoutfolder, laz))
+                            .expect("could not save output png"),
+                        image::ImageFormat::Png,
+                    )
                     .expect("could not save output png");
 
                     fs.copy(
-                        Path::new(&format!("{}/{}_vege.pgw", batchoutfolder, laz)),
-                        Path::new(&format!("{}/{}_vege_bit.pgw", batchoutfolder, laz)),
+                        format!("{}/{}_vege.pgw", batchoutfolder, laz),
+                        format!("{}/{}_vege_bit.pgw", batchoutfolder, laz),
                     )
                     .expect("Could not copy file");
 
                     fs.copy(
-                        Path::new(&format!("{}/{}_vege.pgw", batchoutfolder, laz)),
-                        Path::new(&format!("{}/{}_undergrowth_bit.pgw", batchoutfolder, laz)),
+                        format!("{}/{}_vege.pgw", batchoutfolder, laz),
+                        format!("{}/{}_undergrowth_bit.pgw", batchoutfolder, laz),
                     )
                     .expect("Could not copy file");
                 }

--- a/src/process.rs
+++ b/src/process.rs
@@ -685,9 +685,11 @@ pub fn batch_process(conf: &Config, fs: &impl FileSystem, thread: &String) {
                 .expect("Unable to write to file");
                 pgw_file_out.flush().unwrap();
 
-                let mut orig_img_reader =
-                    image::ImageReader::open(Path::new(&format!("temp{}/undergrowth.png", thread)))
-                        .expect("Opening undergrowth image failed");
+                let mut orig_img_reader = image::ImageReader::new(BufReader::new(
+                    fs.open(format!("temp{}/undergrowth.png", thread))
+                        .expect("Opening undergrowth image failed"),
+                ));
+                orig_img_reader.set_format(image::ImageFormat::Png);
                 orig_img_reader.no_limits();
                 let orig_img = orig_img_reader.decode().unwrap();
                 let mut img = RgbaImage::from_pixel(
@@ -710,9 +712,11 @@ pub fn batch_process(conf: &Config, fs: &impl FileSystem, thread: &String) {
                 )
                 .expect("could not save output png");
 
-                let mut orig_img_reader =
-                    image::ImageReader::open(Path::new(&format!("temp{}/vegetation.png", thread)))
-                        .expect("Opening vegetation image failed");
+                let mut orig_img_reader = image::ImageReader::new(BufReader::new(
+                    fs.open(format!("temp{}/vegetation.png", thread))
+                        .expect("Opening vegetation image failed"),
+                ));
+                orig_img_reader.set_format(image::ImageFormat::Png);
                 orig_img_reader.no_limits();
                 let orig_img = orig_img_reader.decode().unwrap();
                 let mut img = RgbImage::from_pixel(
@@ -745,11 +749,11 @@ pub fn batch_process(conf: &Config, fs: &impl FileSystem, thread: &String) {
                 pgw_file_out.flush().unwrap();
 
                 if vege_bitmode {
-                    let mut orig_img_reader = image::ImageReader::open(Path::new(&format!(
-                        "temp{}/vegetation_bit.png",
-                        thread
-                    )))
-                    .expect("Opening vegetation bit image failed");
+                    let mut orig_img_reader = image::ImageReader::new(BufReader::new(
+                        fs.open(format!("temp{}/vegetation_bit.png", thread))
+                            .expect("Opening vegetation bit bit image failed"),
+                    ));
+                    orig_img_reader.set_format(image::ImageFormat::Png);
                     orig_img_reader.no_limits();
                     let orig_img = orig_img_reader.decode().unwrap();
                     let mut img = GrayImage::from_pixel(
@@ -771,11 +775,11 @@ pub fn batch_process(conf: &Config, fs: &impl FileSystem, thread: &String) {
                     )
                     .expect("could not save output png");
 
-                    let mut orig_img_reader = image::ImageReader::open(Path::new(&format!(
-                        "temp{}/undergrowth_bit.png",
-                        thread
-                    )))
-                    .expect("Opening undergrowth bit image failed");
+                    let mut orig_img_reader = image::ImageReader::new(BufReader::new(
+                        fs.open(format!("temp{}/undergrowth_bit.png", thread))
+                            .expect("Opening undergrowth bit image failed"),
+                    ));
+                    orig_img_reader.set_format(image::ImageFormat::Png);
                     orig_img_reader.no_limits();
                     let orig_img = orig_img_reader.decode().unwrap();
                     let mut img = GrayImage::from_pixel(

--- a/src/process.rs
+++ b/src/process.rs
@@ -232,7 +232,7 @@ pub fn process_tile(
         "xyztemp.xyz.bin", //point cloud in
     )
     .expect("contour generation failed");
-    xyz_03.to_file(tmpfolder.join("xyz_03.hmap")).unwrap();
+    xyz_03.to_file(fs, tmpfolder.join("xyz_03.hmap")).unwrap();
 
     if vegeonly || cliffsonly {
     } else {
@@ -261,7 +261,7 @@ pub fn process_tile(
     if !vegeonly && !cliffsonly {
         if basemapcontours != 0.0 {
             info!("Basemap contours");
-            let xyz2 = HeightMap::from_file(tmpfolder.join("xyz2.hmap"))
+            let xyz2 = HeightMap::from_file(fs, tmpfolder.join("xyz2.hmap"))
                 .expect("could not read xyz2 heightmap");
             contours::heightmap2contours(
                 fs,
@@ -285,7 +285,7 @@ pub fn process_tile(
         timing.start_section("contour generation part 2");
         if !skipknolldetection {
             // contours 2.5
-            let xyz_knolls = HeightMap::from_file(tmpfolder.join("xyz_knolls.hmap"))
+            let xyz_knolls = HeightMap::from_file(fs, tmpfolder.join("xyz_knolls.hmap"))
                 .expect("could not read xyz_knolls heightmap");
             contours::heightmap2contours(
                 fs,

--- a/src/render.rs
+++ b/src/render.rs
@@ -1180,8 +1180,13 @@ pub fn render(
         format!("pullautus_depr{}", thread)
     };
 
-    img.save(&format!("{}.png", filename))
-        .expect("could not save output png");
+    img.write_to(
+        &mut fs
+            .create(format!("{}.png", filename))
+            .expect("could not save output png"),
+        image::ImageFormat::Png,
+    )
+    .expect("could not write image");
 
     let file_in = tmpfolder.join("vegetation.pgw");
     let pgw_file_out = fs

--- a/src/render.rs
+++ b/src/render.rs
@@ -119,8 +119,11 @@ pub fn mtkshaperender(
     let y0 = d[5].trim().parse::<f64>().unwrap();
     // let resvege = d[0].trim().parse::<f64>().unwrap();
 
-    let mut img_reader = image::ImageReader::open(tmpfolder.join("vegetation.png"))
-        .expect("Opening vegetation image failed");
+    let mut img_reader = image::ImageReader::new(BufReader::new(
+        fs.open(tmpfolder.join("vegetation.png"))
+            .expect("Opening vegetation image failed"),
+    ));
+    img_reader.set_format(image::ImageFormat::Png);
     img_reader.no_limits();
     let img = img_reader.decode().unwrap();
     let w = img.width() as f64;
@@ -819,13 +822,19 @@ pub fn render(
         .parse::<f64>()
         .unwrap();
 
-    let mut img_reader = image::ImageReader::open(tmpfolder.join("vegetation.png"))
-        .expect("Opening vegetation image failed");
+    let mut img_reader = image::ImageReader::new(BufReader::new(
+        fs.open(tmpfolder.join("vegetation.png"))
+            .expect("Opening vegetation image failed"),
+    ));
+    img_reader.set_format(image::ImageFormat::Png);
     img_reader.no_limits();
     let img = img_reader.decode().unwrap();
 
-    let mut imgug_reader = image::ImageReader::open(tmpfolder.join("undergrowth.png"))
-        .expect("Opening undergrowth image failed");
+    let mut imgug_reader = image::ImageReader::new(BufReader::new(
+        fs.open(tmpfolder.join("undergrowth.png"))
+            .expect("Opening undergrowth image failed"),
+    ));
+    imgug_reader.set_format(image::ImageFormat::Png);
     imgug_reader.no_limits();
     let imgug = imgug_reader.decode().unwrap();
 
@@ -857,7 +866,10 @@ pub fn render(
 
     let low_file = tmpfolder.join("low.png");
     if fs.exists(&low_file) {
-        let mut low_reader = image::ImageReader::open(low_file).expect("Opening low image failed");
+        let mut low_reader = image::ImageReader::new(BufReader::new(
+            fs.open(low_file).expect("Opening low image failed"),
+        ));
+        low_reader.set_format(image::ImageFormat::Png);
         low_reader.no_limits();
         let low = low_reader.decode().unwrap();
         let low = image::imageops::resize(
@@ -926,8 +938,10 @@ pub fn render(
     // blocks -------------
     let blocks_file = tmpfolder.join("blocks.png");
     if fs.exists(&blocks_file) {
-        let mut blockpurple_reader =
-            image::ImageReader::open(blocks_file).expect("Opening blocks image failed");
+        let mut blockpurple_reader = image::ImageReader::new(BufReader::new(
+            fs.open(blocks_file).expect("Opening blocks image failed"),
+        ));
+        blockpurple_reader.set_format(image::ImageFormat::Png);
         blockpurple_reader.no_limits();
         let blockpurple = blockpurple_reader.decode().unwrap();
         let mut blockpurple = blockpurple.to_rgba8();
@@ -959,8 +973,11 @@ pub fn render(
     // blueblack -------------
     let blueblack_file = tmpfolder.join("blueblack.png");
     if fs.exists(&blueblack_file) {
-        let mut imgbb_reader =
-            image::ImageReader::open(blueblack_file).expect("Opening blueblack image failed");
+        let mut imgbb_reader = image::ImageReader::new(BufReader::new(
+            fs.open(blueblack_file)
+                .expect("Opening blueblack image failed"),
+        ));
+        imgbb_reader.set_format(image::ImageFormat::Png);
         imgbb_reader.no_limits();
         let imgbb = imgbb_reader.decode().unwrap();
         let mut imgbb = imgbb.to_rgba8();
@@ -1161,8 +1178,10 @@ pub fn render(
     // high -------------
     let high_file = tmpfolder.join("high.png");
     if fs.exists(&high_file) {
-        let mut high_reader =
-            image::ImageReader::open(high_file).expect("Opening high image failed");
+        let mut high_reader = image::ImageReader::new(BufReader::new(
+            fs.open(high_file).expect("Opening high image failed"),
+        ));
+        high_reader.set_format(image::ImageFormat::Png);
         high_reader.no_limits();
         let high = high_reader.decode().unwrap();
         let high_thumb = image::imageops::resize(

--- a/src/render.rs
+++ b/src/render.rs
@@ -152,8 +152,7 @@ pub fn mtkshaperender(
     let olive = (194, 176, 33);
 
     let mut shp_files: Vec<PathBuf> = Vec::new();
-    for element in tmpfolder.read_dir().unwrap() {
-        let path = element.unwrap().path();
+    for path in fs.list(tmpfolder).unwrap() {
         if let Some(extension) = path.extension() {
             if extension == "shp" {
                 shp_files.push(path);

--- a/src/render.rs
+++ b/src/render.rs
@@ -105,12 +105,13 @@ pub fn mtkshaperender(
             .map(Mapping::from_str)
             .collect::<Result<Vec<_>, _>>()?;
     }
-    if !tmpfolder.join("vegetation.pgw").exists() {
+
+    let input = tmpfolder.join("vegetation.pgw");
+    if !fs.exists(&input) {
         info!("Could not find vegetation file");
         return Ok(());
     }
 
-    let input = tmpfolder.join("vegetation.pgw");
     let data = fs.read_to_string(input).expect("Can not read input file");
     let d: Vec<&str> = data.split('\n').collect();
 
@@ -738,7 +739,7 @@ pub fn mtkshaperender(
         fs.remove_file(&file).unwrap();
         for ext in ["dbf", "sbx", "prj", "shx", "sbn", "cpg", "qmd"].iter() {
             file.set_extension(ext);
-            if file.exists() {
+            if fs.exists(&file) {
                 println!("Removing file: {:?}", file);
                 fs.remove_file(&file).unwrap();
             }
@@ -773,13 +774,13 @@ pub fn mtkshaperender(
     imgblue.overlay(&mut imgbrowntop, 0.0, 0.0);
 
     let low_file = tmpfolder.join("low.png");
-    if low_file.exists() {
+    if fs.exists(&low_file) {
         let mut low = Canvas::load_from(&low_file);
         imgyellow.overlay(&mut low, 0.0, 0.0);
     }
 
     let high_file = tmpfolder.join("high.png");
-    if high_file.exists() {
+    if fs.exists(&high_file) {
         let mut high = Canvas::load_from(&high_file);
         imgblue.overlay(&mut high, 0.0, 0.0);
     }
@@ -856,7 +857,7 @@ pub fn render(
     image::imageops::overlay(&mut img, &imgug, 0, 0);
 
     let low_file = tmpfolder.join("low.png");
-    if low_file.exists() {
+    if fs.exists(&low_file) {
         let mut low_reader = image::ImageReader::open(low_file).expect("Opening low image failed");
         low_reader.no_limits();
         let low = low_reader.decode().unwrap();
@@ -925,7 +926,7 @@ pub fn render(
     }
     // blocks -------------
     let blocks_file = tmpfolder.join("blocks.png");
-    if blocks_file.exists() {
+    if fs.exists(&blocks_file) {
         let mut blockpurple_reader =
             image::ImageReader::open(blocks_file).expect("Opening blocks image failed");
         blockpurple_reader.no_limits();
@@ -958,7 +959,7 @@ pub fn render(
     }
     // blueblack -------------
     let blueblack_file = tmpfolder.join("blueblack.png");
-    if blueblack_file.exists() {
+    if fs.exists(&blueblack_file) {
         let mut imgbb_reader =
             image::ImageReader::open(blueblack_file).expect("Opening blueblack image failed");
         imgbb_reader.no_limits();
@@ -1160,7 +1161,7 @@ pub fn render(
     }
     // high -------------
     let high_file = tmpfolder.join("high.png");
-    if high_file.exists() {
+    if fs.exists(&high_file) {
         let mut high_reader =
             image::ImageReader::open(high_file).expect("Opening high image failed");
         high_reader.no_limits();

--- a/src/util.rs
+++ b/src/util.rs
@@ -1,33 +1,30 @@
 use std::{
     fmt::Debug,
-    fs::File,
-    io::{self, BufRead},
+    io::{self, BufRead, BufReader},
     path::Path,
     time::Instant,
 };
 
 use log::debug;
 
-pub fn read_lines<P>(filename: P) -> io::Result<io::Lines<io::BufReader<File>>>
-where
-    P: AsRef<Path>,
-{
-    let file = File::open(filename)?;
-    Ok(io::BufReader::new(file).lines())
-}
+use crate::io::fs::FileSystem;
 
 /// Iterates over the lines in a file and calls the callback with a &str reference to each line.
 /// This function does not allocate new strings for each line, as opposed to using
 /// [`io::BufReader::lines()`] as in [`read_lines`].
-pub fn read_lines_no_alloc<P>(filename: P, mut line_callback: impl FnMut(&str)) -> io::Result<()>
+pub fn read_lines_no_alloc<P>(
+    fs: &impl FileSystem,
+    filename: P,
+    mut line_callback: impl FnMut(&str),
+) -> io::Result<()>
 where
     P: AsRef<Path> + Debug,
 {
     debug!("Reading lines from {filename:?}");
     let start = Instant::now();
 
-    let file = File::open(filename)?;
-    let mut reader = io::BufReader::new(file);
+    let file = fs.open(filename)?;
+    let mut reader = BufReader::new(file);
 
     let mut line_buffer = String::new();
     let mut line_count: u32 = 0;

--- a/src/vegetation.rs
+++ b/src/vegetation.rs
@@ -12,10 +12,15 @@ use std::path::Path;
 
 use crate::config::{Config, Zone};
 use crate::io::bytes::FromToBytes;
+use crate::io::fs::FileSystem;
 use crate::io::heightmap::HeightMap;
 use crate::io::xyz::XyzInternalReader;
 
-pub fn makevege(config: &Config, tmpfolder: &Path) -> Result<(), Box<dyn Error>> {
+pub fn makevege(
+    fs: &impl FileSystem,
+    config: &Config,
+    tmpfolder: &Path,
+) -> Result<(), Box<dyn Error>> {
     info!("Generating vegetation...");
 
     let heightmap_in = tmpfolder.join("xyz2.hmap");
@@ -71,7 +76,7 @@ pub fn makevege(config: &Config, tmpfolder: &Path) -> Result<(), Box<dyn Error>>
     let mut noyhit: HashMap<(u64, u64), u64> = HashMap::default();
 
     let mut i = 0;
-    let mut reader = XyzInternalReader::open(&xyz_file_in)?;
+    let mut reader = XyzInternalReader::new(BufReader::new(fs.open(&xyz_file_in)?))?;
     while let Some(r) = reader.next()? {
         if vegethin == 0 || ((i + 1) as u32) % vegethin == 0 {
             let x: f64 = r.x;
@@ -128,7 +133,7 @@ pub fn makevege(config: &Config, tmpfolder: &Path) -> Result<(), Box<dyn Error>>
     let step: f32 = 6.0;
 
     let mut i = 0;
-    let mut reader = XyzInternalReader::open(&xyz_file_in)?;
+    let mut reader = XyzInternalReader::new(BufReader::new(fs.open(&xyz_file_in)?))?;
     while let Some(r) = reader.next()? {
         if vegethin == 0 || ((i + 1) as u32) % vegethin == 0 {
             let x: f64 = r.x;
@@ -420,7 +425,7 @@ pub fn makevege(config: &Config, tmpfolder: &Path) -> Result<(), Box<dyn Error>>
     let buildings = config.buildings;
     let water = config.water;
     if buildings > 0 || water > 0 {
-        let mut reader = XyzInternalReader::open(&xyz_file_in)?;
+        let mut reader = XyzInternalReader::new(BufReader::new(fs.open(&xyz_file_in)?))?;
         while let Some(r) = reader.next()? {
             let (x, y) = (r.x, r.y);
             let c: u8 = r.classification;

--- a/src/vegetation.rs
+++ b/src/vegetation.rs
@@ -6,7 +6,7 @@ use log::info;
 use rustc_hash::FxHashMap as HashMap;
 use std::error::Error;
 use std::f32::consts::SQRT_2;
-use std::io::BufReader;
+use std::io::{BufReader, BufWriter, Write};
 use std::path::Path;
 
 use crate::config::{Config, Zone};
@@ -659,21 +659,28 @@ pub fn makevege(
         )
         .expect("could not save output png");
 
-    std::fs::write(
-        tmpfolder.join("undergrowth.pgw"),
-        format!(
-            "{}\r\n0.0\r\n0.0\r\n{}\r\n{}\r\n{}\r\n",
-            1.0 / tmpfactor,
-            -1.0 / tmpfactor,
-            xmin,
-            ymax,
-        ),
+    let mut writer = BufWriter::new(
+        fs.create(tmpfolder.join("undergrowth.pgw"))
+            .expect("cannot create pgw file"),
+    );
+    write!(
+        &mut writer,
+        "{}\r\n0.0\r\n0.0\r\n{}\r\n{}\r\n{}\r\n",
+        1.0 / tmpfactor,
+        -1.0 / tmpfactor,
+        xmin,
+        ymax,
     )
     .expect("Cannot write pgw file");
 
-    std::fs::write(
-        tmpfolder.join("vegetation.pgw"),
-        format!("1.0\r\n0.0\r\n0.0\r\n-1.0\r\n{}\r\n{}\r\n", xmin, ymax),
+    let mut writer = BufWriter::new(
+        fs.create(tmpfolder.join("vegetation.pgw"))
+            .expect("cannot create pgw file"),
+    );
+    write!(
+        &mut writer,
+        "1.0\r\n0.0\r\n0.0\r\n-1.0\r\n{}\r\n{}\r\n",
+        xmin, ymax
     )
     .expect("Cannot write pgw file");
 

--- a/src/vegetation.rs
+++ b/src/vegetation.rs
@@ -6,7 +6,6 @@ use log::info;
 use rustc_hash::FxHashMap as HashMap;
 use std::error::Error;
 use std::f32::consts::SQRT_2;
-use std::fs::File;
 use std::io::BufReader;
 use std::path::Path;
 
@@ -24,7 +23,7 @@ pub fn makevege(
     info!("Generating vegetation...");
 
     let heightmap_in = tmpfolder.join("xyz2.hmap");
-    let mut reader = BufReader::new(File::open(heightmap_in)?);
+    let mut reader = BufReader::new(fs.open(heightmap_in)?);
     let hmap = HeightMap::from_bytes(&mut reader)?;
 
     // in world coordinates

--- a/src/vegetation.rs
+++ b/src/vegetation.rs
@@ -360,22 +360,41 @@ pub fn makevege(
     }
 
     imgye2
-        .save(tmpfolder.join("yellow.png"))
+        .write_to(
+            &mut fs
+                .create(tmpfolder.join("yellow.png"))
+                .expect("error saving png"),
+            image::ImageFormat::Png,
+        )
         .expect("could not save output png");
+
     imggr1
-        .save(tmpfolder.join("greens.png"))
+        .write_to(
+            &mut fs
+                .create(tmpfolder.join("greens.png"))
+                .expect("error saving png"),
+            image::ImageFormat::Png,
+        )
         .expect("could not save output png");
 
     let mut img = DynamicImage::ImageRgb8(imggr1);
     image::imageops::overlay(&mut img, &DynamicImage::ImageRgba8(imgye2), 0, 0);
-    img.save(tmpfolder.join("vegetation.png"))
-        .expect("could not save output png");
+
+    img.write_to(
+        &mut fs
+            .create(tmpfolder.join("vegetation.png"))
+            .expect("error saving png"),
+        image::ImageFormat::Png,
+    )
+    .expect("could not save output png");
 
     // drop img to free memory
     drop(img);
 
     if vege_bitmode {
-        let g_img = image::open(tmpfolder.join("greens.png")).expect("Opening image failed");
+        let g_img = fs
+            .read_image(tmpfolder.join("greens.png"))
+            .expect("Opening image failed");
         let mut g_img = g_img.to_rgb8();
         for pixel in g_img.pixels_mut() {
             let mut found = false;
@@ -391,11 +410,19 @@ pub fn makevege(
             }
         }
         let g_img = DynamicImage::ImageRgb8(g_img).to_luma8();
+
         g_img
-            .save(tmpfolder.join("greens_bit.png"))
+            .write_to(
+                &mut fs
+                    .create(tmpfolder.join("greens_bit.png"))
+                    .expect("error saving png"),
+                image::ImageFormat::Png,
+            )
             .expect("could not save output png");
 
-        let y_img = image::open(tmpfolder.join("yellow.png")).expect("Opening image failed");
+        let y_img = fs
+            .read_image(tmpfolder.join("yellow.png"))
+            .expect("Opening image failed");
         let mut y_img = y_img.to_rgba8();
         for pixel in y_img.pixels_mut() {
             if pixel[0] == ye2[0] && pixel[1] == ye2[1] && pixel[2] == ye2[2] && pixel[3] == ye2[3]
@@ -406,15 +433,27 @@ pub fn makevege(
             }
         }
         let y_img = DynamicImage::ImageRgba8(y_img).to_luma_alpha8();
+
         y_img
-            .save(tmpfolder.join("yellow_bit.png"))
+            .write_to(
+                &mut fs
+                    .create(tmpfolder.join("yellow_bit.png"))
+                    .expect("error saving png"),
+                image::ImageFormat::Png,
+            )
             .expect("could not save output png");
 
         let mut img_bit = DynamicImage::ImageLuma8(g_img);
         let img_bit2 = DynamicImage::ImageLumaA8(y_img);
         image::imageops::overlay(&mut img_bit, &img_bit2, 0, 0);
+
         img_bit
-            .save(tmpfolder.join("vegetation_bit.png"))
+            .write_to(
+                &mut fs
+                    .create(tmpfolder.join("vegetation_bit.png"))
+                    .expect("error saving png"),
+                image::ImageFormat::Png,
+            )
             .expect("could not save output png");
     }
 
@@ -457,7 +496,12 @@ pub fn makevege(
     }
 
     imgwater
-        .save(tmpfolder.join("blueblack.png"))
+        .write_to(
+            &mut fs
+                .create(tmpfolder.join("blueblack.png"))
+                .expect("error saving png"),
+            image::ImageFormat::Png,
+        )
         .expect("could not save output png");
 
     drop(imgwater); // explicitly drop imgwater to free memory
@@ -596,11 +640,23 @@ pub fn makevege(
         x += bf32 * step;
     }
     imgug
-        .save(tmpfolder.join("undergrowth.png"))
+        .write_to(
+            &mut fs
+                .create(tmpfolder.join("undergrowth.png"))
+                .expect("error saving png"),
+            image::ImageFormat::Png,
+        )
         .expect("could not save output png");
+
     let img_ug_bit_b = median_filter(&img_ug_bit, (bf32 * step) as u32, (bf32 * step) as u32);
+
     img_ug_bit_b
-        .save(tmpfolder.join("undergrowth_bit.png"))
+        .write_to(
+            &mut fs
+                .create(tmpfolder.join("undergrowth_bit.png"))
+                .expect("error saving png"),
+            image::ImageFormat::Png,
+        )
         .expect("could not save output png");
 
     std::fs::write(


### PR DESCRIPTION
As a step towards a proof-of-concept web app, this PR introduces a `FileSystem` trait that encapsulates all interactions that `pullauta` does with the file system. An object implementing the trait for the local file system is passed to all processing functions (hence the many changes). This does not change any of the processing logic, just how they interact with the filesystem.

In addition to that, this PR also introduces a simple in-memory implementation of the `FileSystem` trait that stores files and folders as `Vec<u8>` in-memory instead of interacting with the real file system. This is what is needed for being able to perform the processing in the browser where no file system is available. Also added quite few unit tests for this :100: 

For testing, a new configuration flag `experimental_use_in_memory_fs` is introduced that, when enabled, causes the normal single-file processing and batch mode processing to use the in-memory file system instead. It will copy the input files to memory before processing, and write the results (like `pullautus.png` ) back to the file system after processing. Funnily enough, this does remove about 10% of processing for my single-file tests :rocket: Although it does use another 1Gb of RAM :laughing: 