### PR TITLE
Feature/use grid

### DIFF
--- a/src/cliffs.rs
+++ b/src/cliffs.rs
@@ -276,6 +276,9 @@ pub fn makecliffs(
         .expect("Cannot write dxf file");
     let c2_limit = 2.6 * 2.75;
 
+    // if we drop this already here, we can reuse the memory for the second list_alt
+    drop(list_alt);
+
     let mut list_alt = Vec2D::new(
         (((xmax - xmin) / 3.0).ceil() + 1.0) as usize,
         (((ymax - ymin) / 3.0).ceil() + 1.0) as usize,

--- a/src/merge.rs
+++ b/src/merge.rs
@@ -575,12 +575,7 @@ pub fn smoothjoin(
     let size = hmap.scale;
     let xmax = (hmap.grid.width() - 1) as u64;
     let ymax = (hmap.grid.height() - 1) as u64;
-
-    // Temporarily convert to HashMap for not having to go through all the logic below.
-    let mut xyz: HashMap<(u64, u64), f64> = HashMap::default();
-    for (x, y, h) in hmap.grid.iter() {
-        xyz.insert((x as u64, y as u64), h);
-    }
+    let xyz = hmap.grid;
 
     let mut steepness = Vec2D::new((xmax + 1) as usize, (ymax + 1) as usize, f64::NAN);
 
@@ -590,7 +585,7 @@ pub fn smoothjoin(
             let mut high: f64 = f64::MIN;
             for ii in i - 1..i + 2 {
                 for jj in j - 1..j + 2 {
-                    let tmp = *xyz.get(&(ii, jj)).unwrap_or(&0.0);
+                    let tmp = xyz[(ii as usize, jj as usize)];
                     if tmp < low {
                         low = tmp;
                     }
@@ -801,8 +796,8 @@ pub fn smoothjoin(
                     if (xm - xstart) / size == ((xm - xstart) / size).floor() {
                         let xx = ((xm - xstart) / size).floor() as u64;
                         let yy = ((ym - ystart) / size).floor() as u64;
-                        let h1 = *xyz.get(&(xx, yy)).unwrap_or(&0.0);
-                        let h2 = *xyz.get(&(xx, yy + 1)).unwrap_or(&0.0);
+                        let h1 = xyz[(xx as usize, yy as usize)];
+                        let h2 = xyz[(xx as usize, yy as usize + 1)];
                         let h3 = h1 * (yy as f64 + 1.0 - (ym - ystart) / size)
                             + h2 * ((ym - ystart) / size - yy as f64);
                         h = (h3 / interval + 0.5).floor() * interval;
@@ -812,8 +807,8 @@ pub fn smoothjoin(
                     {
                         let xx = ((xm - xstart) / size).floor() as u64;
                         let yy = ((ym - ystart) / size).floor() as u64;
-                        let h1 = *xyz.get(&(xx, yy)).unwrap_or(&0.0);
-                        let h2 = *xyz.get(&(xx + 1, yy)).unwrap_or(&0.0);
+                        let h1 = xyz[(xx as usize, yy as usize)];
+                        let h2 = xyz[(xx as usize + 1, yy as usize)];
                         let h3 = h1 * (xx as f64 + 1.0 - (xm - xstart) / size)
                             + h2 * ((xm - xstart) / size - xx as f64);
                         h = (h3 / interval + 0.5).floor() * interval;
@@ -853,7 +848,7 @@ pub fn smoothjoin(
                 let foo_x = ((x_avg - xstart) / size).floor() as u64;
                 let foo_y = ((y_avg - ystart) / size).floor() as u64;
 
-                let h_center = *xyz.get(&(foo_x, foo_y)).unwrap_or(&0.0);
+                let h_center = xyz[(foo_x as usize, foo_y as usize)];
 
                 let mut hit = 0;
 

--- a/src/merge.rs
+++ b/src/merge.rs
@@ -579,13 +579,13 @@ pub fn smoothjoin(
 
     let mut steepness = Vec2D::new((xmax + 1) as usize, (ymax + 1) as usize, f64::NAN);
 
-    for i in 1..xmax {
-        for j in 1..ymax {
+    for i in 1..xmax as usize {
+        for j in 1..ymax as usize {
             let mut low: f64 = f64::MAX;
             let mut high: f64 = f64::MIN;
             for ii in i - 1..i + 2 {
                 for jj in j - 1..j + 2 {
-                    let tmp = xyz[(ii as usize, jj as usize)];
+                    let tmp = xyz[(ii, jj)];
                     if tmp < low {
                         low = tmp;
                     }
@@ -594,7 +594,7 @@ pub fn smoothjoin(
                     }
                 }
             }
-            steepness[(i as usize, j as usize)] = high - low;
+            steepness[(i, j)] = high - low;
         }
     }
     let input = tmpfolder.join("out.dxf");
@@ -794,10 +794,10 @@ pub fn smoothjoin(
                     let xm = el_x[l][m];
                     let ym = el_y[l][m];
                     if (xm - xstart) / size == ((xm - xstart) / size).floor() {
-                        let xx = ((xm - xstart) / size).floor() as u64;
-                        let yy = ((ym - ystart) / size).floor() as u64;
-                        let h1 = xyz[(xx as usize, yy as usize)];
-                        let h2 = xyz[(xx as usize, yy as usize + 1)];
+                        let xx = ((xm - xstart) / size).floor() as usize;
+                        let yy = ((ym - ystart) / size).floor() as usize;
+                        let h1 = xyz[(xx, yy)];
+                        let h2 = xyz[(xx, yy + 1)];
                         let h3 = h1 * (yy as f64 + 1.0 - (ym - ystart) / size)
                             + h2 * ((ym - ystart) / size - yy as f64);
                         h = (h3 / interval + 0.5).floor() * interval;
@@ -805,10 +805,10 @@ pub fn smoothjoin(
                     } else if m < el_x_len - 1
                         && (el_y[l][m] - ystart) / size == ((el_y[l][m] - ystart) / size).floor()
                     {
-                        let xx = ((xm - xstart) / size).floor() as u64;
-                        let yy = ((ym - ystart) / size).floor() as u64;
-                        let h1 = xyz[(xx as usize, yy as usize)];
-                        let h2 = xyz[(xx as usize + 1, yy as usize)];
+                        let xx = ((xm - xstart) / size).floor() as usize;
+                        let yy = ((ym - ystart) / size).floor() as usize;
+                        let h1 = xyz[(xx, yy)];
+                        let h2 = xyz[(xx + 1, yy)];
                         let h3 = h1 * (xx as f64 + 1.0 - (xm - xstart) / size)
                             + h2 * ((xm - xstart) / size - xx as f64);
                         h = (h3 / interval + 0.5).floor() * interval;
@@ -845,10 +845,10 @@ pub fn smoothjoin(
                     }
                     m += 1;
                 }
-                let foo_x = ((x_avg - xstart) / size).floor() as u64;
-                let foo_y = ((y_avg - ystart) / size).floor() as u64;
+                let foo_x = ((x_avg - xstart) / size).floor() as usize;
+                let foo_y = ((y_avg - ystart) / size).floor() as usize;
 
-                let h_center = xyz[(foo_x as usize, foo_y as usize)];
+                let h_center = xyz[(foo_x, foo_y)];
 
                 let mut hit = 0;
 

--- a/src/render.rs
+++ b/src/render.rs
@@ -493,11 +493,7 @@ pub fn draw_curves(
 
         x0 = xstart;
 
-        // Temporarily convert to HashMap for not having to go through all the logic below.
-        let mut xyz: HashMap<(usize, usize), f64> = HashMap::default();
-        for (x, y, h) in hmap.grid.iter() {
-            xyz.insert((x, y), h);
-        }
+        let xyz = &hmap.grid;
         y0 = hmap.maxy();
 
         let sxmax = hmap.grid.width() - 1;
@@ -508,29 +504,12 @@ pub fn draw_curves(
                 let mut det: f64 = 0.0;
                 let mut high: f64 = f64::MIN;
 
-                let mut temp =
-                    (xyz.get(&(i - 4, j)).unwrap_or(&0.0) - xyz.get(&(i, j)).unwrap_or(&0.0)).abs()
-                        / 4.0;
-                let temp2 =
-                    (xyz.get(&(i, j)).unwrap_or(&0.0) - xyz.get(&(i + 4, j)).unwrap_or(&0.0)).abs()
-                        / 4.0;
-                let det2 = (xyz.get(&(i, j)).unwrap_or(&0.0)
-                    - 0.5
-                        * (xyz.get(&(i - 4, j)).unwrap_or(&0.0)
-                            + xyz.get(&(i + 4, j)).unwrap_or(&0.0)))
-                .abs()
-                    - 0.05
-                        * (xyz.get(&(i - 4, j)).unwrap_or(&0.0)
-                            - xyz.get(&(i + 4, j)).unwrap_or(&0.0))
-                        .abs();
-                let mut porr = (((xyz.get(&(i - 6, j)).unwrap_or(&0.0)
-                    - xyz.get(&(i + 6, j)).unwrap_or(&0.0))
-                    / 12.0)
-                    .abs()
-                    - ((xyz.get(&(i - 3, j)).unwrap_or(&0.0)
-                        - xyz.get(&(i + 3, j)).unwrap_or(&0.0))
-                        / 6.0)
-                        .abs())
+                let mut temp = (xyz[(i - 4, j)] - xyz[(i, j)]).abs() / 4.0;
+                let temp2 = (xyz[(i, j)] - xyz[(i + 4, j)]).abs() / 4.0;
+                let det2 = (xyz[(i, j)] - 0.5 * (xyz[(i - 4, j)] + xyz[(i + 4, j)])).abs()
+                    - 0.05 * (xyz[(i - 4, j)] - xyz[(i + 4, j)]).abs();
+                let mut porr = (((xyz[(i - 6, j)] - xyz[(i + 6, j)]) / 12.0).abs()
+                    - ((xyz[(i - 3, j)] - xyz[(i + 3, j)]) / 6.0).abs())
                 .abs();
 
                 if det2 > det {
@@ -543,29 +522,12 @@ pub fn draw_curves(
                     high = temp;
                 }
 
-                let mut temp =
-                    (xyz.get(&(i, j - 4)).unwrap_or(&0.0) - xyz.get(&(i, j)).unwrap_or(&0.0)).abs()
-                        / 4.0;
-                let temp2 =
-                    (xyz.get(&(i, j)).unwrap_or(&0.0) - xyz.get(&(i, j - 4)).unwrap_or(&0.0)).abs()
-                        / 4.0;
-                let det2 = (xyz.get(&(i, j)).unwrap_or(&0.0)
-                    - 0.5
-                        * (xyz.get(&(i, j - 4)).unwrap_or(&0.0)
-                            + xyz.get(&(i, j + 4)).unwrap_or(&0.0)))
-                .abs()
-                    - 0.05
-                        * (xyz.get(&(i, j - 4)).unwrap_or(&0.0)
-                            - xyz.get(&(i, j + 4)).unwrap_or(&0.0))
-                        .abs();
-                let porr2 = (((xyz.get(&(i, j - 6)).unwrap_or(&0.0)
-                    - xyz.get(&(i, j + 6)).unwrap_or(&0.0))
-                    / 12.0)
-                    .abs()
-                    - ((xyz.get(&(i, j - 3)).unwrap_or(&0.0)
-                        - xyz.get(&(i, j + 3)).unwrap_or(&0.0))
-                        / 6.0)
-                        .abs())
+                let mut temp = (xyz[(i, j - 4)] - xyz[(i, j)]).abs() / 4.0;
+                let temp2 = (xyz[(i, j)] - xyz[(i, j - 4)]).abs() / 4.0;
+                let det2 = (xyz[(i, j)] - 0.5 * (xyz[(i, j - 4)] + xyz[(i, j + 4)])).abs()
+                    - 0.05 * (xyz[(i, j - 4)] - xyz[(i, j + 4)]).abs();
+                let porr2 = (((xyz[(i, j - 6)] - xyz[(i, j + 6)]) / 12.0).abs()
+                    - ((xyz[(i, j - 3)] - xyz[(i, j + 3)]) / 6.0).abs())
                 .abs();
 
                 if porr2 > porr {
@@ -581,31 +543,12 @@ pub fn draw_curves(
                     high = temp;
                 }
 
-                let mut temp = (xyz.get(&(i - 4, j - 4)).unwrap_or(&0.0)
-                    - xyz.get(&(i, j)).unwrap_or(&0.0))
-                .abs()
-                    / 5.6;
-                let temp2 = (xyz.get(&(i, j)).unwrap_or(&0.0)
-                    - xyz.get(&(i + 4, j + 4)).unwrap_or(&0.0))
-                .abs()
-                    / 5.6;
-                let det2 = (xyz.get(&(i, j)).unwrap_or(&0.0)
-                    - 0.5
-                        * (xyz.get(&(i - 4, j - 4)).unwrap_or(&0.0)
-                            + xyz.get(&(i + 4, j + 4)).unwrap_or(&0.0)))
-                .abs()
-                    - 0.05
-                        * (xyz.get(&(i - 4, j - 4)).unwrap_or(&0.0)
-                            - xyz.get(&(i + 4, j + 4)).unwrap_or(&0.0))
-                        .abs();
-                let porr2 = (((xyz.get(&(i - 6, j - 6)).unwrap_or(&0.0)
-                    - xyz.get(&(i + 6, j + 6)).unwrap_or(&0.0))
-                    / 17.0)
-                    .abs()
-                    - ((xyz.get(&(i - 3, j - 3)).unwrap_or(&0.0)
-                        - xyz.get(&(i + 3, j + 3)).unwrap_or(&0.0))
-                        / 8.5)
-                        .abs())
+                let mut temp = (xyz[(i - 4, j - 4)] - xyz[(i, j)]).abs() / 5.6;
+                let temp2 = (xyz[(i, j)] - xyz[(i + 4, j + 4)]).abs() / 5.6;
+                let det2 = (xyz[(i, j)] - 0.5 * (xyz[(i - 4, j - 4)] + xyz[(i + 4, j + 4)])).abs()
+                    - 0.05 * (xyz[(i - 4, j - 4)] - xyz[(i + 4, j + 4)]).abs();
+                let porr2 = (((xyz[(i - 6, j - 6)] - xyz[(i + 6, j + 6)]) / 17.0).abs()
+                    - ((xyz[(i - 3, j - 3)] - xyz[(i + 3, j + 3)]) / 8.5).abs())
                 .abs();
 
                 if porr2 > porr {
@@ -621,31 +564,12 @@ pub fn draw_curves(
                     high = temp;
                 }
 
-                let mut temp = (xyz.get(&(i - 4, j + 4)).unwrap_or(&0.0)
-                    - xyz.get(&(i, j)).unwrap_or(&0.0))
-                .abs()
-                    / 5.6;
-                let temp2 = (xyz.get(&(i, j)).unwrap_or(&0.0)
-                    - xyz.get(&(i + 4, j - 4)).unwrap_or(&0.0))
-                .abs()
-                    / 5.6;
-                let det2 = (xyz.get(&(i, j)).unwrap_or(&0.0)
-                    - 0.5
-                        * (xyz.get(&(i + 4, j - 4)).unwrap_or(&0.0)
-                            + xyz.get(&(i - 4, j + 4)).unwrap_or(&0.0)))
-                .abs()
-                    - 0.05
-                        * (xyz.get(&(i + 4, j - 4)).unwrap_or(&0.0)
-                            - xyz.get(&(i - 4, j + 4)).unwrap_or(&0.0))
-                        .abs();
-                let porr2 = (((xyz.get(&(i + 6, j - 6)).unwrap_or(&0.0)
-                    - xyz.get(&(i - 6, j + 6)).unwrap_or(&0.0))
-                    / 17.0)
-                    .abs()
-                    - ((xyz.get(&(i + 3, j - 3)).unwrap_or(&0.0)
-                        - xyz.get(&(i - 3, j + 3)).unwrap_or(&0.0))
-                        / 8.5)
-                        .abs())
+                let mut temp = (xyz[(i - 4, j + 4)] - xyz[(i, j)]).abs() / 5.6;
+                let temp2 = (xyz[(i, j)] - xyz[(i + 4, j - 4)]).abs() / 5.6;
+                let det2 = (xyz[(i, j)] - 0.5 * (xyz[(i + 4, j - 4)] + xyz[(i - 4, j + 4)])).abs()
+                    - 0.05 * (xyz[(i + 4, j - 4)] - xyz[(i - 4, j + 4)]).abs();
+                let porr2 = (((xyz[(i + 6, j - 6)] - xyz[(i - 6, j + 6)]) / 17.0).abs()
+                    - ((xyz[(i + 3, j - 3)] - xyz[(i - 3, j + 3)]) / 8.5).abs())
                 .abs();
 
                 if porr2 > porr {

--- a/src/render.rs
+++ b/src/render.rs
@@ -679,24 +679,16 @@ pub fn draw_curves(
                 for i in 0..x.len() {
                     help[i] = false;
                     help2[i] = true;
-                    let xx = (((x[i] / 600.0 * 254.0 * scalefactor + x0) - xstart) / size).floor();
-                    let yy = (((-y[i] / 600.0 * 254.0 * scalefactor + y0) - ystart) / size).floor();
+                    let xx = (((x[i] / 600.0 * 254.0 * scalefactor + x0) - xstart) / size).floor()
+                        as usize;
+                    let yy = (((-y[i] / 600.0 * 254.0 * scalefactor + y0) - ystart) / size).floor()
+                        as usize;
                     if curvew != 1.5
                         || formline == 0.0
-                        || steepness.get(&(xx as usize, yy as usize)).unwrap_or(&0.0)
-                            < &formlinesteepness
-                        || steepness
-                            .get(&(xx as usize, yy as usize + 1))
-                            .unwrap_or(&0.0)
-                            < &formlinesteepness
-                        || steepness
-                            .get(&(xx as usize + 1, yy as usize))
-                            .unwrap_or(&0.0)
-                            < &formlinesteepness
-                        || steepness
-                            .get(&(xx as usize + 1, yy as usize + 1))
-                            .unwrap_or(&0.0)
-                            < &formlinesteepness
+                        || steepness.get(&(xx, yy)).unwrap_or(&0.0) < &formlinesteepness
+                        || steepness.get(&(xx, yy + 1)).unwrap_or(&0.0) < &formlinesteepness
+                        || steepness.get(&(xx + 1, yy)).unwrap_or(&0.0) < &formlinesteepness
+                        || steepness.get(&(xx + 1, yy + 1)).unwrap_or(&0.0) < &formlinesteepness
                     {
                         help[i] = true;
                     }

--- a/src/vegetation.rs
+++ b/src/vegetation.rs
@@ -30,12 +30,7 @@ pub fn makevege(
     let xstart = hmap.xoffset;
     let ystart = hmap.yoffset;
     let size = hmap.scale;
-
-    // Temporarily convert to HashMap for not having to go through all the logic below.
-    let mut xyz: HashMap<(u64, u64), f64> = HashMap::default();
-    for (x, y, h) in hmap.grid.iter() {
-        xyz.insert((x as u64, y as u64), h);
-    }
+    let xyz = &hmap.grid;
 
     let thresholds = &config.thresholds;
     let block = config.greendetectsize;
@@ -102,12 +97,10 @@ pub fn makevege(
 
                 if r3 == 2
                     || h < yellowheight
-                        + *xyz
-                            .get(&(
-                                ((x - xmin) / size).floor() as u64,
-                                ((y - ymin) / size).floor() as u64,
-                            ))
-                            .unwrap_or(&0.0)
+                        + xyz[(
+                            ((x - xmin) / size).floor() as usize,
+                            ((y - ymin) / size).floor() as usize,
+                        )]
                 {
                     *yhit.entry((xx, yy)).or_insert(0) += 1;
                 } else if r4 == 1 && r5 == 1 {
@@ -149,12 +142,12 @@ pub fn makevege(
                     *firsthit.entry((xx, yy)).or_insert(0) += 1;
                 }
 
-                let xx = ((x - xmin) / size).floor() as u64;
-                let yy = ((y - ymin) / size).floor() as u64;
-                let a = *xyz.get(&(xx, yy)).unwrap_or(&0.0);
-                let b = *xyz.get(&(xx + 1, yy)).unwrap_or(&0.0);
-                let c = *xyz.get(&(xx, yy + 1)).unwrap_or(&0.0);
-                let d = *xyz.get(&(xx + 1, yy + 1)).unwrap_or(&0.0);
+                let xx = ((x - xmin) / size).floor() as usize;
+                let yy = ((y - ymin) / size).floor() as usize;
+                let a = xyz[(xx, yy)];
+                let b = xyz[(xx + 1, yy)];
+                let c = xyz[(xx, yy + 1)];
+                let d = xyz[(xx + 1, yy + 1)];
 
                 let distx = (x - xmin) / size - xx as f64;
                 let disty = (y - ymin) / size - yy as f64;
@@ -282,12 +275,10 @@ pub fn makevege(
     for x in 2..w as usize {
         for y in 2..h as usize {
             let roof = *top.get(&(x as u64, y as u64)).unwrap_or(&0.0)
-                - *xyz
-                    .get(&(
-                        (x as f64 * block / size).floor() as u64,
-                        (y as f64 * block / size).floor() as u64,
-                    ))
-                    .unwrap_or(&0.0);
+                - xyz[(
+                    (x as f64 * block / size).floor() as usize,
+                    (y as f64 * block / size).floor() as usize,
+                )];
 
             let mut firsthit2 = *firsthit.get(&(x as u64, y as u64)).unwrap_or(&0);
             for i in (x - 2)..x + 3_usize {


### PR DESCRIPTION
Use the heightmap grid directly instead of a HashMap. The conversion to HashMap was left to not have too many changes in # . This PR now fixes that and removes the use of the intermediate HasMap. Memory usage and performance improvements (HashMaps are slow compared to Vecs!)