### PR TITLE
fix: write images buffered

### DIFF
--- a/src/blocks.rs
+++ b/src/blocks.rs
@@ -4,7 +4,11 @@ use imageproc::filter::median_filter;
 use imageproc::rect::Rect;
 use log::info;
 use rustc_hash::FxHashMap as HashMap;
-use std::{error::Error, io::BufReader, path::Path};
+use std::{
+    error::Error,
+    io::{BufReader, BufWriter},
+    path::Path,
+};
 
 use crate::io::{bytes::FromToBytes, fs::FileSystem, heightmap::HeightMap, xyz::XyzInternalReader};
 
@@ -70,9 +74,10 @@ pub fn blocks(fs: &impl FileSystem, tmpfolder: &Path) -> Result<(), Box<dyn Erro
     }
 
     img2.write_to(
-        &mut fs
-            .create(tmpfolder.join("blocks2.png"))
-            .expect("error saving png"),
+        &mut BufWriter::new(
+            fs.create(tmpfolder.join("blocks2.png"))
+                .expect("error saving png"),
+        ),
         image::ImageFormat::Png,
     )
     .expect("error saving png");
@@ -85,9 +90,10 @@ pub fn blocks(fs: &impl FileSystem, tmpfolder: &Path) -> Result<(), Box<dyn Erro
     img = image::DynamicImage::ImageRgb8(median_filter(&img.to_rgb8(), filter_size, filter_size));
 
     img.write_to(
-        &mut fs
-            .create(tmpfolder.join("blocks.png"))
-            .expect("error saving png"),
+        &mut BufWriter::new(
+            fs.create(tmpfolder.join("blocks.png"))
+                .expect("error saving png"),
+        ),
         image::ImageFormat::Png,
     )
     .expect("error saving png");

--- a/src/cliffs.rs
+++ b/src/cliffs.rs
@@ -355,9 +355,10 @@ pub fn makecliffs(
         .expect("Cannot write dxf file");
 
     img.write_to(
-        &mut fs
-            .create(tmpfolder.join("c2.png"))
-            .expect("could not save output png"),
+        &mut BufWriter::new(
+            fs.create(tmpfolder.join("c2.png"))
+                .expect("could not save output png"),
+        ),
         image::ImageFormat::Png,
     )
     .expect("could not save output png");

--- a/src/io/fs/mod.rs
+++ b/src/io/fs/mod.rs
@@ -35,15 +35,15 @@ pub trait FileSystem: std::fmt::Debug {
     /// Copy a file.
     fn copy(&self, from: impl AsRef<Path>, to: impl AsRef<Path>) -> Result<(), io::Error>;
 
-    /// Write an image with the desired format.
-    fn read_image(
+    /// Read an image in PNG format.
+    fn read_image_png(
         &self,
         path: impl AsRef<Path>,
     ) -> Result<image::DynamicImage, image::error::ImageError> {
-        image::ImageReader::new(std::io::BufReader::new(
+        let mut reader = image::ImageReader::new(std::io::BufReader::new(
             self.open(path).expect("Could not open file"),
-        ))
-        .with_guessed_format()?
-        .decode()
+        ));
+        reader.set_format(image::ImageFormat::Png);
+        reader.decode()
     }
 }

--- a/src/merge.rs
+++ b/src/merge.rs
@@ -28,7 +28,9 @@ fn merge_png(
     for png in png_files.iter() {
         let filename = png.as_path().file_name().unwrap().to_str().unwrap();
         let full_filename = format!("{}/{}", batchoutfolder, filename);
-        let img = fs.read_image(&full_filename).expect("Opening image failed");
+        let img = fs
+            .read_image_png(&full_filename)
+            .expect("Opening image failed");
 
         let width = img.width() as f64;
         let height = img.height() as f64;
@@ -71,7 +73,7 @@ fn merge_png(
         let pgw = Path::new(&pgw);
         let filesize = fs.file_size(png).unwrap();
         if fs.exists(png) && fs.exists(pgw) && filesize > 0 {
-            let img = fs.read_image(png).expect("Opening image failed");
+            let img = fs.read_image_png(png).expect("Opening image failed");
             let width = img.width() as f64;
             let height = img.height() as f64;
 

--- a/src/merge.rs
+++ b/src/merge.rs
@@ -97,17 +97,19 @@ fn merge_png(
     }
 
     im.write_to(
-        &mut fs
-            .create(format!("{}.jpg", outfilename))
-            .expect("could not save output jpg"),
+        &mut BufWriter::new(
+            fs.create(format!("{}.jpg", outfilename))
+                .expect("could not save output jpg"),
+        ),
         image::ImageFormat::Jpeg,
     )
     .expect("could not save output jpg");
 
     im.write_to(
-        &mut fs
-            .create(format!("{}.png", outfilename))
-            .expect("could not save output png"),
+        &mut BufWriter::new(
+            fs.create(format!("{}.png", outfilename))
+                .expect("could not save output png"),
+        ),
         image::ImageFormat::Png,
     )
     .expect("could not save output Png");

--- a/src/process.rs
+++ b/src/process.rs
@@ -575,9 +575,10 @@ pub fn batch_process(conf: &Config, fs: &impl FileSystem, thread: &String) {
             );
 
             img.write_to(
-                &mut fs
-                    .create(format!("pullautus{}.png", thread))
-                    .expect("could not save output png"),
+                &mut BufWriter::new(
+                    fs.create(format!("pullautus{}.png", thread))
+                        .expect("could not save output png"),
+                ),
                 image::ImageFormat::Png,
             )
             .expect("could not save output png");
@@ -598,9 +599,10 @@ pub fn batch_process(conf: &Config, fs: &impl FileSystem, thread: &String) {
             );
 
             img.write_to(
-                &mut fs
-                    .create(format!("pullautus_depr{}.png", thread))
-                    .expect("could not save output png"),
+                &mut BufWriter::new(
+                    fs.create(format!("pullautus_depr{}.png", thread))
+                        .expect("could not save output png"),
+                ),
                 image::ImageFormat::Png,
             )
             .expect("could not save output png");
@@ -710,9 +712,10 @@ pub fn batch_process(conf: &Config, fs: &impl FileSystem, thread: &String) {
                 );
 
                 img.write_to(
-                    &mut fs
-                        .create(format!("{}/{}_undergrowth.png", batchoutfolder, laz))
-                        .expect("could not save output png"),
+                    &mut BufWriter::new(
+                        fs.create(format!("{}/{}_undergrowth.png", batchoutfolder, laz))
+                            .expect("could not save output png"),
+                    ),
                     image::ImageFormat::Png,
                 )
                 .expect("could not save output png");
@@ -732,9 +735,10 @@ pub fn batch_process(conf: &Config, fs: &impl FileSystem, thread: &String) {
                 image::imageops::overlay(&mut img, &orig_img.to_rgb8(), -dx as i64, -dy as i64);
 
                 img.write_to(
-                    &mut fs
-                        .create(format!("{}/{}_vege.png", batchoutfolder, laz))
-                        .expect("could not save output png"),
+                    &mut BufWriter::new(
+                        fs.create(format!("{}/{}_vege.png", batchoutfolder, laz))
+                            .expect("could not save output png"),
+                    ),
                     image::ImageFormat::Png,
                 )
                 .expect("could not save output png");
@@ -773,9 +777,10 @@ pub fn batch_process(conf: &Config, fs: &impl FileSystem, thread: &String) {
                         -dy as i64,
                     );
                     img.write_to(
-                        &mut fs
-                            .create(format!("{}/{}_vege_bit.png", batchoutfolder, laz))
-                            .expect("could not save output png"),
+                        &mut BufWriter::new(
+                            fs.create(format!("{}/{}_vege_bit.png", batchoutfolder, laz))
+                                .expect("could not save output png"),
+                        ),
                         image::ImageFormat::Png,
                     )
                     .expect("could not save output png");
@@ -799,9 +804,10 @@ pub fn batch_process(conf: &Config, fs: &impl FileSystem, thread: &String) {
                         -dy as i64,
                     );
                     img.write_to(
-                        &mut fs
-                            .create(format!("{}/{}_undergrowth_bit.png", batchoutfolder, laz))
-                            .expect("could not save output png"),
+                        &mut BufWriter::new(
+                            fs.create(format!("{}/{}_undergrowth_bit.png", batchoutfolder, laz))
+                                .expect("could not save output png"),
+                        ),
                         image::ImageFormat::Png,
                     )
                     .expect("could not save output png");

--- a/src/process.rs
+++ b/src/process.rs
@@ -560,7 +560,7 @@ pub fn batch_process(conf: &Config, fs: &impl FileSystem, thread: &String) {
             .expect("Could not copy file");
 
             let orig_img = fs
-                .read_image(format!("pullautus{}.png", thread))
+                .read_image_png(format!("pullautus{}.png", thread))
                 .expect("Opening image failed");
             let mut img = RgbImage::from_pixel(
                 ((maxx - minx) * 600.0 / 254.0 / scalefactor + 2.0) as u32,
@@ -583,7 +583,7 @@ pub fn batch_process(conf: &Config, fs: &impl FileSystem, thread: &String) {
             .expect("could not save output png");
 
             let orig_img = fs
-                .read_image(format!("pullautus_depr{}.png", thread))
+                .read_image_png(format!("pullautus_depr{}.png", thread))
                 .expect("Opening image failed");
             let mut img = RgbImage::from_pixel(
                 ((maxx - minx) * 600.0 / 254.0 / scalefactor + 2.0) as u32,

--- a/src/render.rs
+++ b/src/render.rs
@@ -1200,9 +1200,10 @@ pub fn render(
     };
 
     img.write_to(
-        &mut fs
-            .create(format!("{}.png", filename))
-            .expect("could not save output png"),
+        &mut BufWriter::new(
+            fs.create(format!("{}.png", filename))
+                .expect("could not save output png"),
+        ),
         image::ImageFormat::Png,
     )
     .expect("could not write image");

--- a/src/vegetation.rs
+++ b/src/vegetation.rs
@@ -393,7 +393,7 @@ pub fn makevege(
 
     if vege_bitmode {
         let g_img = fs
-            .read_image(tmpfolder.join("greens.png"))
+            .read_image_png(tmpfolder.join("greens.png"))
             .expect("Opening image failed");
         let mut g_img = g_img.to_rgb8();
         for pixel in g_img.pixels_mut() {
@@ -421,7 +421,7 @@ pub fn makevege(
             .expect("could not save output png");
 
         let y_img = fs
-            .read_image(tmpfolder.join("yellow.png"))
+            .read_image_png(tmpfolder.join("yellow.png"))
             .expect("Opening image failed");
         let mut y_img = y_img.to_rgba8();
         for pixel in y_img.pixels_mut() {

--- a/src/vegetation.rs
+++ b/src/vegetation.rs
@@ -361,18 +361,20 @@ pub fn makevege(
 
     imgye2
         .write_to(
-            &mut fs
-                .create(tmpfolder.join("yellow.png"))
-                .expect("error saving png"),
+            &mut BufWriter::new(
+                fs.create(tmpfolder.join("yellow.png"))
+                    .expect("error saving png"),
+            ),
             image::ImageFormat::Png,
         )
         .expect("could not save output png");
 
     imggr1
         .write_to(
-            &mut fs
-                .create(tmpfolder.join("greens.png"))
-                .expect("error saving png"),
+            &mut BufWriter::new(
+                fs.create(tmpfolder.join("greens.png"))
+                    .expect("error saving png"),
+            ),
             image::ImageFormat::Png,
         )
         .expect("could not save output png");
@@ -381,9 +383,10 @@ pub fn makevege(
     image::imageops::overlay(&mut img, &DynamicImage::ImageRgba8(imgye2), 0, 0);
 
     img.write_to(
-        &mut fs
-            .create(tmpfolder.join("vegetation.png"))
-            .expect("error saving png"),
+        &mut BufWriter::new(
+            fs.create(tmpfolder.join("vegetation.png"))
+                .expect("error saving png"),
+        ),
         image::ImageFormat::Png,
     )
     .expect("could not save output png");
@@ -413,9 +416,10 @@ pub fn makevege(
 
         g_img
             .write_to(
-                &mut fs
-                    .create(tmpfolder.join("greens_bit.png"))
-                    .expect("error saving png"),
+                &mut BufWriter::new(
+                    fs.create(tmpfolder.join("greens_bit.png"))
+                        .expect("error saving png"),
+                ),
                 image::ImageFormat::Png,
             )
             .expect("could not save output png");
@@ -436,9 +440,10 @@ pub fn makevege(
 
         y_img
             .write_to(
-                &mut fs
-                    .create(tmpfolder.join("yellow_bit.png"))
-                    .expect("error saving png"),
+                &mut BufWriter::new(
+                    fs.create(tmpfolder.join("yellow_bit.png"))
+                        .expect("error saving png"),
+                ),
                 image::ImageFormat::Png,
             )
             .expect("could not save output png");
@@ -449,9 +454,10 @@ pub fn makevege(
 
         img_bit
             .write_to(
-                &mut fs
-                    .create(tmpfolder.join("vegetation_bit.png"))
-                    .expect("error saving png"),
+                &mut BufWriter::new(
+                    fs.create(tmpfolder.join("vegetation_bit.png"))
+                        .expect("error saving png"),
+                ),
                 image::ImageFormat::Png,
             )
             .expect("could not save output png");
@@ -497,9 +503,10 @@ pub fn makevege(
 
     imgwater
         .write_to(
-            &mut fs
-                .create(tmpfolder.join("blueblack.png"))
-                .expect("error saving png"),
+            &mut BufWriter::new(
+                fs.create(tmpfolder.join("blueblack.png"))
+                    .expect("error saving png"),
+            ),
             image::ImageFormat::Png,
         )
         .expect("could not save output png");
@@ -641,9 +648,10 @@ pub fn makevege(
     }
     imgug
         .write_to(
-            &mut fs
-                .create(tmpfolder.join("undergrowth.png"))
-                .expect("error saving png"),
+            &mut BufWriter::new(
+                fs.create(tmpfolder.join("undergrowth.png"))
+                    .expect("error saving png"),
+            ),
             image::ImageFormat::Png,
         )
         .expect("could not save output png");
@@ -652,9 +660,10 @@ pub fn makevege(
 
     img_ug_bit_b
         .write_to(
-            &mut fs
-                .create(tmpfolder.join("undergrowth_bit.png"))
-                .expect("error saving png"),
+            &mut BufWriter::new(
+                fs.create(tmpfolder.join("undergrowth_bit.png"))
+                    .expect("error saving png"),
+            ),
             image::ImageFormat::Png,
         )
         .expect("could not save output png");


### PR DESCRIPTION
Fixes a regression introduced in # where images were written to the file system unbuffered, causing longer processing times. This was observed in the execution time of the  _merge_ steps in the batch regression job which increasesd from 2 to 22s. Although it was never caught in the review :octocat: 

Also made the format explicit in `read_image` helper function.