### PR TITLE
Feature/improved contours

### DIFF
--- a/src/cliffs.rs
+++ b/src/cliffs.rs
@@ -191,8 +191,8 @@ pub fn makecliffs(
                 for &(x0, y0, h0) in d.iter() {
                     let cliff_length = 1.47;
                     let mut steep = steepness[(
-                        ((x0 - xstart) / size + 0.5) as usize,
-                        ((y0 - ystart) / size + 0.5) as usize,
+                        ((x0 - xstart) / size) as usize,
+                        ((y0 - ystart) / size) as usize,
                     )] - flat_place;
                     if steep.is_nan() {
                         steep = -flat_place;

--- a/src/contours.rs
+++ b/src/contours.rs
@@ -577,3 +577,46 @@ fn check_obj_in(
         }
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use crate::contours;
+
+    #[test]
+    fn test_grid2contours_empty() {
+        let grid = crate::vec2d::Vec2D::new(5, 5, 0.0);
+        let contours = contours::grid2contours(&grid, 1.0);
+        assert!(
+            contours.is_empty(),
+            "Expected no contours for a uniform grid"
+        );
+    }
+
+    #[test]
+    fn test_grid2contours_single_contour() {
+        let mut grid = crate::vec2d::Vec2D::new(5, 5, 0.0);
+        grid[(2, 2)] = 1.1;
+        let contours = contours::grid2contours(&grid, 1.0);
+        println!("Contours: {:?}", contours);
+        assert_eq!(
+            contours.len(),
+            1,
+            "Expected one contour for a single contour line"
+        );
+        assert_eq!(contours[0].len(), 4, "Expected contour to have 4 points");
+    }
+
+    #[test]
+    fn test_grid2contours_single_contour2() {
+        let mut grid = crate::vec2d::Vec2D::new(5, 5, 2.0);
+        grid[(2, 2)] = 1.1;
+        let contours = contours::grid2contours(&grid, 1.0);
+        println!("Contours: {:?}", contours);
+        assert_eq!(
+            contours.len(),
+            1,
+            "Expected one contour for a single contour line"
+        );
+        assert_eq!(contours[0].len(), 4, "Expected contour to have 4 points");
+    }
+}

--- a/src/contours.rs
+++ b/src/contours.rs
@@ -333,6 +333,8 @@ pub fn grid2contours(heightmap: &Vec2D<f64>, cinterval: f64) -> Vec<Vec<(f64, f6
         let mut obj = Vec::<(i64, i64, u8)>::new();
         let mut curves: HashMap<(i64, i64, u8), (i64, i64)> = HashMap::default();
 
+        // for i in 0..(avg_alt.width() - 1) {
+        //     for j in 0..(avg_alt.height() - 1) {
         for i in 1..(w - 1) {
             for j in 2..(h - 1) {
                 let mut a = avg_alt[(i, j)];
@@ -340,141 +342,142 @@ pub fn grid2contours(heightmap: &Vec2D<f64>, cinterval: f64) -> Vec<Vec<(f64, f6
                 let mut c = avg_alt[(i + 1, j)];
                 let mut d = avg_alt[(i + 1, j + 1)];
 
+                // if all corners are below or above the level, skip
                 if a < level && b < level && c < level && d < level
                     || a > level && b > level && c > level && d > level
                 {
-                    // skip
-                } else {
-                    let temp: f64 = (a / v + 0.5).floor() * v;
-                    if (a - temp).abs() < 0.05 {
-                        if a - temp < 0.0 {
-                            a = temp - 0.05;
-                        } else {
-                            a = temp + 0.05;
-                        }
-                    }
+                    continue;
+                }
 
-                    let temp: f64 = (b / v + 0.5).floor() * v;
-                    if (b - temp).abs() < 0.05 {
-                        if b - temp < 0.0 {
-                            b = temp - 0.05;
-                        } else {
-                            b = temp + 0.05;
-                        }
+                let temp: f64 = (a / v + 0.5).floor() * v;
+                if (a - temp).abs() < 0.05 {
+                    if a - temp < 0.0 {
+                        a = temp - 0.05;
+                    } else {
+                        a = temp + 0.05;
                     }
+                }
 
-                    let temp: f64 = (c / v + 0.5).floor() * v;
-                    if (c - temp).abs() < 0.05 {
-                        if c - temp < 0.0 {
-                            c = temp - 0.05;
-                        } else {
-                            c = temp + 0.05;
-                        }
+                let temp: f64 = (b / v + 0.5).floor() * v;
+                if (b - temp).abs() < 0.05 {
+                    if b - temp < 0.0 {
+                        b = temp - 0.05;
+                    } else {
+                        b = temp + 0.05;
                     }
+                }
 
-                    let temp: f64 = (d / v + 0.5).floor() * v;
-                    if (d - temp).abs() < 0.05 {
-                        if d - temp < 0.0 {
-                            d = temp - 0.05;
-                        } else {
-                            d = temp + 0.05;
-                        }
+                let temp: f64 = (c / v + 0.5).floor() * v;
+                if (c - temp).abs() < 0.05 {
+                    if c - temp < 0.0 {
+                        c = temp - 0.05;
+                    } else {
+                        c = temp + 0.05;
                     }
+                }
 
-                    if a < b {
-                        if level < b && level > a {
-                            let x1: f64 = i as f64;
-                            let y1: f64 = j as f64 + (level - a) / (b - a);
-                            if level > c {
-                                let x2: f64 = i as f64 + (b - level) / (b - c);
-                                let y2: f64 = j as f64 + (level - c) / (b - c);
-                                check_obj_in(&mut obj, &mut curves, x1, x2, y1, y2);
-                            } else if level < c {
-                                let x2: f64 = i as f64 + (level - a) / (c - a);
-                                let y2: f64 = j as f64;
-                                check_obj_in(&mut obj, &mut curves, x1, x2, y1, y2);
-                            }
-                        }
-                    } else if b < a && level < a && level > b {
+                let temp: f64 = (d / v + 0.5).floor() * v;
+                if (d - temp).abs() < 0.05 {
+                    if d - temp < 0.0 {
+                        d = temp - 0.05;
+                    } else {
+                        d = temp + 0.05;
+                    }
+                }
+
+                if a < b {
+                    if level < b && level > a {
                         let x1: f64 = i as f64;
-                        let y1: f64 = j as f64 + (a - level) / (a - b);
-                        if level < c {
-                            let x2: f64 = i as f64 + (level - b) / (c - b);
-                            let y2: f64 = j as f64 + (c - level) / (c - b);
+                        let y1: f64 = j as f64 + (level - a) / (b - a);
+                        if level > c {
+                            let x2: f64 = i as f64 + (b - level) / (b - c);
+                            let y2: f64 = j as f64 + (level - c) / (b - c);
                             check_obj_in(&mut obj, &mut curves, x1, x2, y1, y2);
-                        } else if level > c {
-                            let x2: f64 = i as f64 + (a - level) / (a - c);
+                        } else if level < c {
+                            let x2: f64 = i as f64 + (level - a) / (c - a);
                             let y2: f64 = j as f64;
                             check_obj_in(&mut obj, &mut curves, x1, x2, y1, y2);
                         }
                     }
+                } else if b < a && level < a && level > b {
+                    let x1: f64 = i as f64;
+                    let y1: f64 = j as f64 + (a - level) / (a - b);
+                    if level < c {
+                        let x2: f64 = i as f64 + (level - b) / (c - b);
+                        let y2: f64 = j as f64 + (c - level) / (c - b);
+                        check_obj_in(&mut obj, &mut curves, x1, x2, y1, y2);
+                    } else if level > c {
+                        let x2: f64 = i as f64 + (a - level) / (a - c);
+                        let y2: f64 = j as f64;
+                        check_obj_in(&mut obj, &mut curves, x1, x2, y1, y2);
+                    }
+                }
 
-                    if a < c {
-                        if level < c && level > a {
-                            let x1: f64 = i as f64 + (level - a) / (c - a);
-                            let y1: f64 = j as f64;
-                            if level > b {
-                                let x2: f64 = i as f64 + (level - b) / (c - b);
-                                let y2: f64 = j as f64 + (c - level) / (c - b);
-                                check_obj_in(&mut obj, &mut curves, x1, x2, y1, y2);
-                            }
-                        }
-                    } else if a > c && level < a && level > c {
-                        let x1: f64 = i as f64 + (a - level) / (a - c);
+                if a < c {
+                    if level < c && level > a {
+                        let x1: f64 = i as f64 + (level - a) / (c - a);
                         let y1: f64 = j as f64;
+                        if level > b {
+                            let x2: f64 = i as f64 + (level - b) / (c - b);
+                            let y2: f64 = j as f64 + (c - level) / (c - b);
+                            check_obj_in(&mut obj, &mut curves, x1, x2, y1, y2);
+                        }
+                    }
+                } else if a > c && level < a && level > c {
+                    let x1: f64 = i as f64 + (a - level) / (a - c);
+                    let y1: f64 = j as f64;
+                    if level < b {
+                        let x2: f64 = i as f64 + (b - level) / (b - c);
+                        let y2: f64 = j as f64 + (level - c) / (b - c);
+                        check_obj_in(&mut obj, &mut curves, x1, x2, y1, y2);
+                    }
+                }
+
+                if c < d {
+                    if level < d && level > c {
+                        let x1: f64 = i as f64 + 1.0;
+                        let y1: f64 = j as f64 + (level - c) / (d - c);
                         if level < b {
+                            let x2: f64 = i as f64 + (b - level) / (b - c);
+                            let y2: f64 = j as f64 + (level - c) / (b - c);
+                            check_obj_in(&mut obj, &mut curves, x1, x2, y1, y2);
+                        } else if level > b {
+                            let x2: f64 = i as f64 + (level - b) / (d - b);
+                            let y2: f64 = j as f64 + 1.0;
+                            check_obj_in(&mut obj, &mut curves, x1, x2, y1, y2);
+                        }
+                    }
+                } else if c > d && level < c && level > d {
+                    let x1: f64 = i as f64 + 1.0;
+                    let y1: f64 = j as f64 + (c - level) / (c - d);
+                    if level > b {
+                        let x2: f64 = i as f64 + (level - b) / (c - b);
+                        let y2: f64 = j as f64 + (c - level) / (c - b);
+                        check_obj_in(&mut obj, &mut curves, x1, x2, y1, y2);
+                    } else if level < b {
+                        let x2: f64 = i as f64 + (b - level) / (b - d);
+                        let y2: f64 = j as f64 + 1.0;
+                        check_obj_in(&mut obj, &mut curves, x1, x2, y1, y2);
+                    }
+                }
+
+                if d < b {
+                    if level < b && level > d {
+                        let x1: f64 = i as f64 + (b - level) / (b - d);
+                        let y1: f64 = j as f64 + 1.0;
+                        if level > c {
                             let x2: f64 = i as f64 + (b - level) / (b - c);
                             let y2: f64 = j as f64 + (level - c) / (b - c);
                             check_obj_in(&mut obj, &mut curves, x1, x2, y1, y2);
                         }
                     }
-
-                    if c < d {
-                        if level < d && level > c {
-                            let x1: f64 = i as f64 + 1.0;
-                            let y1: f64 = j as f64 + (level - c) / (d - c);
-                            if level < b {
-                                let x2: f64 = i as f64 + (b - level) / (b - c);
-                                let y2: f64 = j as f64 + (level - c) / (b - c);
-                                check_obj_in(&mut obj, &mut curves, x1, x2, y1, y2);
-                            } else if level > b {
-                                let x2: f64 = i as f64 + (level - b) / (d - b);
-                                let y2: f64 = j as f64 + 1.0;
-                                check_obj_in(&mut obj, &mut curves, x1, x2, y1, y2);
-                            }
-                        }
-                    } else if c > d && level < c && level > d {
-                        let x1: f64 = i as f64 + 1.0;
-                        let y1: f64 = j as f64 + (c - level) / (c - d);
-                        if level > b {
-                            let x2: f64 = i as f64 + (level - b) / (c - b);
-                            let y2: f64 = j as f64 + (c - level) / (c - b);
-                            check_obj_in(&mut obj, &mut curves, x1, x2, y1, y2);
-                        } else if level < b {
-                            let x2: f64 = i as f64 + (b - level) / (b - d);
-                            let y2: f64 = j as f64 + 1.0;
-                            check_obj_in(&mut obj, &mut curves, x1, x2, y1, y2);
-                        }
-                    }
-
-                    if d < b {
-                        if level < b && level > d {
-                            let x1: f64 = i as f64 + (b - level) / (b - d);
-                            let y1: f64 = j as f64 + 1.0;
-                            if level > c {
-                                let x2: f64 = i as f64 + (b - level) / (b - c);
-                                let y2: f64 = j as f64 + (level - c) / (b - c);
-                                check_obj_in(&mut obj, &mut curves, x1, x2, y1, y2);
-                            }
-                        }
-                    } else if b < d && level < d && level > b {
-                        let x1: f64 = i as f64 + (level - b) / (d - b);
-                        let y1: f64 = j as f64 + 1.0;
-                        if level < c {
-                            let x2: f64 = i as f64 + (level - b) / (c - b);
-                            let y2: f64 = j as f64 + (c - level) / (c - b);
-                            check_obj_in(&mut obj, &mut curves, x1, x2, y1, y2);
-                        }
+                } else if b < d && level < d && level > b {
+                    let x1: f64 = i as f64 + (level - b) / (d - b);
+                    let y1: f64 = j as f64 + 1.0;
+                    if level < c {
+                        let x2: f64 = i as f64 + (level - b) / (c - b);
+                        let y2: f64 = j as f64 + (c - level) / (c - b);
+                        check_obj_in(&mut obj, &mut curves, x1, x2, y1, y2);
                     }
                 }
             }

--- a/src/contours.rs
+++ b/src/contours.rs
@@ -285,7 +285,7 @@ pub fn heightmap2contours(
 /// Returns a vector of polylines, each represented as a vector of (x, y) tuples in
 /// grid-coordinates.
 /// For now the returned polylines are not annotated with their height.
-/// Note: this will Clone the provided `heightmap`
+/// Note: this will Clone the provided `heightmap`.
 pub fn grid2contours(heightmap: &Vec2D<f64>, cinterval: f64) -> Vec<Vec<(f64, f64)>> {
     // clone the heightmap so that we can perform the correction below
     let mut avg_alt = heightmap.clone();
@@ -321,7 +321,8 @@ pub fn grid2contours(heightmap: &Vec2D<f64>, cinterval: f64) -> Vec<Vec<(f64, f6
 
     let v = cinterval;
 
-    let mut level: f64 = (hmin / v).floor() * v;
+    // we start at the first level that is above hmin (anything below that will just have empty contours)
+    let mut level: f64 = (hmin / v).ceil() * v;
 
     let mut polylines = Vec::<Vec<(f64, f64)>>::new();
 

--- a/src/io/heightmap.rs
+++ b/src/io/heightmap.rs
@@ -23,14 +23,16 @@ impl HeightMap {
     pub fn miny(&self) -> f64 {
         self.yoffset
     }
-    /// Get the maximum x-coordinate of the heightmap
+    /// Get the maximum x-coordinate of the heightmap. This is the coordinate farthest away from zero (eg. the right side of the grid),
+    /// which actually does not lie in a cell in the grid, but rather at the edge of the last cell.
     pub fn maxx(&self) -> f64 {
-        self.xoffset + self.scale * (self.grid.width().saturating_sub(1)) as f64
+        self.xoffset + self.scale * self.grid.width() as f64
     }
 
-    /// Get the maximum y-coordinate of the heightmap
+    /// Get the maximum y-coordinate of the heightmap. This is the coordinate farthest away from zero (eg. the top side of the grid),
+    /// which actually does not lie in a cell in the grid, but rather at the edge of the last cell.
     pub fn maxy(&self) -> f64 {
-        self.yoffset + self.scale * (self.grid.height().saturating_sub(1)) as f64
+        self.yoffset + self.scale * self.grid.height() as f64
     }
 
     pub fn iter(&self) -> impl Iterator<Item = (f64, f64, f64)> + '_ {

--- a/src/render.rs
+++ b/src/render.rs
@@ -557,6 +557,12 @@ pub fn draw_curves(
                         as usize;
                     let yy = (((-y[i] / 600.0 * 254.0 * scalefactor + y0) - ystart) / size).floor()
                         as usize;
+
+                    // make sure indices are within bounds for the grid lookups
+                    if xx >= xyz.width() - 1 || yy >= xyz.height() - 1 || xx < 1 || yy < 1 {
+                        continue;
+                    }
+
                     if curvew != 1.5
                         || formline == 0.0
                         || steepness[(xx, yy)] < formlinesteepness

--- a/src/vegetation.rs
+++ b/src/vegetation.rs
@@ -243,7 +243,7 @@ pub fn makevege(
     let scalefactor = config.scalefactor;
 
     let img_width = (w_block as f64 * block) as u32;
-    let img_height = (w_block as f64 * block) as u32;
+    let img_height = (h_block as f64 * block) as u32;
 
     // render yellow as multiple small squares
     let ye2 = Rgba([255, 219, 166, 255]);

--- a/src/vegetation.rs
+++ b/src/vegetation.rs
@@ -245,28 +245,7 @@ pub fn makevege(
     let img_width = (w_block as f64 * block) as u32;
     let img_height = (w_block as f64 * block) as u32;
 
-    let greens = (0..greenshades.len())
-        .map(|i| {
-            Rgb([
-                (greentone - greentone / (greenshades.len() - 1) as f64 * i as f64) as u8,
-                (254.0 - (74.0 / (greenshades.len() - 1) as f64) * i as f64) as u8,
-                (greentone - greentone / (greenshades.len() - 1) as f64 * i as f64) as u8,
-            ])
-        })
-        .collect::<Vec<_>>();
-
-    let mut aveg = 0;
-    let mut avecount = 0;
-
-    for x in 1..w_block {
-        for y in 1..h_block {
-            if ghit[(x, y)] > 1 {
-                aveg += firsthit[(x, y)];
-                avecount += 1;
-            }
-        }
-    }
-    let aveg = aveg as f64 / avecount as f64;
+    // render yellow as multiple small squares
     let ye2 = Rgba([255, 219, 166, 255]);
     let mut imgye2 = RgbaImage::from_pixel(img_width, img_height, Rgba([255, 255, 255, 0]));
     for x in 0..(w_3 - 2) {
@@ -290,6 +269,33 @@ pub fn makevege(
             }
         }
     }
+
+    // render green gradients
+    let greens = (0..greenshades.len())
+        .map(|i| {
+            Rgb([
+                (greentone - greentone / (greenshades.len() - 1) as f64 * i as f64) as u8,
+                (254.0 - (74.0 / (greenshades.len() - 1) as f64) * i as f64) as u8,
+                (greentone - greentone / (greenshades.len() - 1) as f64 * i as f64) as u8,
+            ])
+        })
+        .collect::<Vec<_>>();
+
+    // compute global average firsthit
+    let aveg = {
+        let mut aveg = 0;
+        let mut avecount = 0;
+
+        for x in 0..w_block {
+            for y in 0..h_block {
+                if ghit[(x, y)] > 1 {
+                    aveg += firsthit[(x, y)];
+                    avecount += 1;
+                }
+            }
+        }
+        aveg as f64 / avecount as f64
+    };
 
     let mut imggr1 = RgbImage::from_pixel(img_width, img_height, Rgb([255, 255, 255]));
     for x in 2..w_block {

--- a/src/vegetation.rs
+++ b/src/vegetation.rs
@@ -85,27 +85,24 @@ pub fn makevege(
             let r4 = r.number_of_returns;
             let r5 = r.return_number;
 
-            // TODO: remove check (point is always in bounds since the heightmap covers _at least_ all points)
-            if x > xmin && y > ymin {
-                let xx = ((x - xmin) / block) as usize;
-                let yy = ((y - ymin) / block) as usize;
-                let t = &mut top[(xx, yy)];
-                if h > *t {
-                    *t = h;
-                }
-                let xx = ((x - xmin) / 3.0) as usize;
-                let yy = ((y - ymin) / 3.0) as usize;
+            let xx = ((x - xmin) / block) as usize;
+            let yy = ((y - ymin) / block) as usize;
+            let t = &mut top[(xx, yy)];
+            if h > *t {
+                *t = h;
+            }
+            let xx = ((x - xmin) / 3.0) as usize;
+            let yy = ((y - ymin) / 3.0) as usize;
 
-                if r3 == 2
-                    || h < yellowheight
-                        + xyz[(((x - xmin) / size) as usize, ((y - ymin) / size) as usize)]
-                {
-                    yhit[(xx, yy)] += 1;
-                } else if r4 == 1 && r5 == 1 {
-                    noyhit[(xx, yy)] += yellowfirstlast;
-                } else {
-                    noyhit[(xx, yy)] += 1;
-                }
+            if r3 == 2
+                || h < yellowheight
+                    + xyz[(((x - xmin) / size) as usize, ((y - ymin) / size) as usize)]
+            {
+                yhit[(xx, yy)] += 1;
+            } else if r4 == 1 && r5 == 1 {
+                noyhit[(xx, yy)] += yellowfirstlast;
+            } else {
+                noyhit[(xx, yy)] += 1;
             }
         }
 
@@ -142,95 +139,92 @@ pub fn makevege(
             let r4 = r.number_of_returns;
             let r5 = r.return_number;
 
-            // TODO: same here, remove!
-            if x > xmin && y > ymin {
-                if r5 == 1 {
-                    let xx = ((x - xmin) / block) as usize;
-                    let yy = ((y - ymin) / block) as usize;
-                    firsthit[(xx, yy)] += 1;
-                }
-
-                // linear interpolation of the height at the point based on the surrpoinding cells in the heightmap
-                let thelele = {
-                    let xx = ((x - xmin) / size) as usize;
-                    let yy = ((y - ymin) / size) as usize;
-
-                    let a = xyz[(xx, yy)];
-
-                    // if we are on the edge, simply extend the values
-                    let (b, c, d) = if xx < xyz.width() - 1 && yy < xyz.height() - 1 {
-                        // inside, take all values
-                        (xyz[(xx + 1, yy)], xyz[(xx, yy + 1)], xyz[(xx + 1, yy + 1)])
-                    } else if xx < xyz.width() - 1 {
-                        // on right edge, extend to the right
-                        (xyz[(xx + 1, yy)], a, a)
-                    } else if yy < xyz.height() - 1 {
-                        // on bottom edge, extend downwards
-                        (a, xyz[(xx, yy + 1)], a)
-                    } else {
-                        // in corner, use this height for all
-                        (a, a, a)
-                    };
-
-                    let distx = (x - xmin) / size - xx as f64;
-                    let disty = (y - ymin) / size - yy as f64;
-
-                    // linear interpolation of the elevation at the point
-                    let ab = a * (1.0 - distx) + b * distx;
-                    let cd = c * (1.0 - distx) + d * distx;
-                    ab * (1.0 - disty) + cd * disty
-                };
-
-                let xx = ((x - xmin) / block / (step as f64) + 0.5) as usize;
-                let yy = ((y - ymin) / block / (step as f64) + 0.5) as usize;
-                let hh = h - thelele;
-                let ug_entry = &mut ug[(xx, yy)];
-                if hh <= 1.2 {
-                    if r3 == 2 {
-                        ug_entry.ugg += 1.0;
-                    } else if hh > 0.25 {
-                        ug_entry.ug += 1;
-                    } else {
-                        ug_entry.ugg += 1.0;
-                    }
-                } else {
-                    ug_entry.ugg += 0.05;
-                }
-
+            if r5 == 1 {
                 let xx = ((x - xmin) / block) as usize;
                 let yy = ((y - ymin) / block) as usize;
-                if r3 == 2 || greenground >= hh {
-                    if r4 == 1 && r5 == 1 {
-                        ghit[(xx, yy)] += firstandlastreturnasground;
-                    } else {
-                        ghit[(xx, yy)] += 1;
-                    }
+                firsthit[(xx, yy)] += 1;
+            }
+
+            // linear interpolation of the height at the point based on the surrpoinding cells in the heightmap
+            let thelele = {
+                let xx = ((x - xmin) / size) as usize;
+                let yy = ((y - ymin) / size) as usize;
+
+                let a = xyz[(xx, yy)];
+
+                // if we are on the edge, simply extend the values
+                let (b, c, d) = if xx < xyz.width() - 1 && yy < xyz.height() - 1 {
+                    // inside, take all values
+                    (xyz[(xx + 1, yy)], xyz[(xx, yy + 1)], xyz[(xx + 1, yy + 1)])
+                } else if xx < xyz.width() - 1 {
+                    // on right edge, extend to the right
+                    (xyz[(xx + 1, yy)], a, a)
+                } else if yy < xyz.height() - 1 {
+                    // on bottom edge, extend downwards
+                    (a, xyz[(xx, yy + 1)], a)
                 } else {
-                    let mut last = 1.0;
-                    if r4 == r5 {
-                        last = lastfactor;
-                        if hh < 5.0 {
-                            last = firstandlastfactor;
-                        }
-                    }
+                    // in corner, use this height for all
+                    (a, a, a)
+                };
 
-                    let top_val = top[(xx, yy)];
-                    for &Zone {
-                        low,
-                        high,
-                        roof,
-                        factor,
-                    } in config.zones.iter()
-                    {
-                        if hh >= low && hh < high && top_val - thelele < roof {
-                            greenhit[(xx, yy)] += (factor * last) as f32;
-                            break;
-                        }
-                    }
+                let distx = (x - xmin) / size - xx as f64;
+                let disty = (y - ymin) / size - yy as f64;
 
-                    if greenhigh < hh {
-                        highit[(xx, yy)] += 1;
+                // linear interpolation of the elevation at the point
+                let ab = a * (1.0 - distx) + b * distx;
+                let cd = c * (1.0 - distx) + d * distx;
+                ab * (1.0 - disty) + cd * disty
+            };
+
+            let xx = ((x - xmin) / block / (step as f64) + 0.5) as usize;
+            let yy = ((y - ymin) / block / (step as f64) + 0.5) as usize;
+            let hh = h - thelele;
+            let ug_entry = &mut ug[(xx, yy)];
+            if hh <= 1.2 {
+                if r3 == 2 {
+                    ug_entry.ugg += 1.0;
+                } else if hh > 0.25 {
+                    ug_entry.ug += 1;
+                } else {
+                    ug_entry.ugg += 1.0;
+                }
+            } else {
+                ug_entry.ugg += 0.05;
+            }
+
+            let xx = ((x - xmin) / block) as usize;
+            let yy = ((y - ymin) / block) as usize;
+            if r3 == 2 || greenground >= hh {
+                if r4 == 1 && r5 == 1 {
+                    ghit[(xx, yy)] += firstandlastreturnasground;
+                } else {
+                    ghit[(xx, yy)] += 1;
+                }
+            } else {
+                let mut last = 1.0;
+                if r4 == r5 {
+                    last = lastfactor;
+                    if hh < 5.0 {
+                        last = firstandlastfactor;
                     }
+                }
+
+                let top_val = top[(xx, yy)];
+                for &Zone {
+                    low,
+                    high,
+                    roof,
+                    factor,
+                } in config.zones.iter()
+                {
+                    if hh >= low && hh < high && top_val - thelele < roof {
+                        greenhit[(xx, yy)] += (factor * last) as f32;
+                        break;
+                    }
+                }
+
+                if greenhigh < hh {
+                    highit[(xx, yy)] += 1;
                 }
             }
         }

--- a/src/vegetation.rs
+++ b/src/vegetation.rs
@@ -118,8 +118,8 @@ pub fn makevege(
 
     let step: f32 = 6.0;
 
-    let w_block_step = ((xmax - xmin) / (block * step as f64)).ceil() as usize + 1;
-    let h_block_step = ((ymax - ymin) / (block * step as f64)).ceil() as usize + 1;
+    let w_block_step = ((xmax - xmin) / (block * step as f64)).ceil() as usize;
+    let h_block_step = ((ymax - ymin) / (block * step as f64)).ceil() as usize;
 
     #[derive(Default, Clone)]
     struct UggItem {
@@ -176,8 +176,8 @@ pub fn makevege(
                 ab * (1.0 - disty) + cd * disty
             };
 
-            let xx = ((x - xmin) / block / (step as f64) + 0.5) as usize;
-            let yy = ((y - ymin) / block / (step as f64) + 0.5) as usize;
+            let xx = ((x - xmin) / block / (step as f64)) as usize;
+            let yy = ((y - ymin) / block / (step as f64)) as usize;
             let hh = h - thelele;
             let ug_entry = &mut ug[(xx, yy)];
             if hh <= 1.2 {
@@ -209,6 +209,7 @@ pub fn makevege(
                     }
                 }
 
+                // NOTE: the use of top here means that we cannot combine the two processing loops into one
                 let top_val = top[(xx, yy)];
                 for &Zone {
                     low,
@@ -233,8 +234,6 @@ pub fn makevege(
     }
     // rebind the variables to be non-mut for the rest of the function
     let (firsthit, ug, ghit, greenhit, highit) = (firsthit, ug, ghit, greenhit, highit);
-
-    let scalefactor = config.scalefactor;
 
     let img_width = (w_block as f64 * block) as u32;
     let img_height = (h_block as f64 * block) as u32;
@@ -521,6 +520,8 @@ pub fn makevege(
         .expect("could not save output png");
 
     drop(imgwater); // explicitly drop imgwater to free memory
+
+    let scalefactor = config.scalefactor;
 
     let underg = Rgba([64, 121, 0, 255]);
     let tmpfactor = (600.0 / 254.0 / scalefactor) as f32;

--- a/src/vegetation.rs
+++ b/src/vegetation.rs
@@ -240,15 +240,10 @@ pub fn makevege(
     // rebind the variables to be non-mut for the rest of the function
     let (firsthit, ug, ghit, greenhit, highit) = (firsthit, ug, ghit, greenhit, highit);
 
-    let w = (xmax - xmin).floor() / block;
-    let h = (ymax - ymin).floor() / block;
-    let wy = (xmax - xmin).floor() / 3.0;
-    let hy = (ymax - ymin).floor() / 3.0;
-
     let scalefactor = config.scalefactor;
 
-    let img_width = (w * block) as u32;
-    let img_height = (h * block) as u32;
+    let img_width = (w_block as f64 * block) as u32;
+    let img_height = (w_block as f64 * block) as u32;
 
     let greens = (0..greenshades.len())
         .map(|i| {
@@ -263,8 +258,8 @@ pub fn makevege(
     let mut aveg = 0;
     let mut avecount = 0;
 
-    for x in 1..(w as usize) {
-        for y in 1..(h as usize) {
+    for x in 1..w_block {
+        for y in 1..h_block {
             if ghit[(x, y)] > 1 {
                 aveg += firsthit[(x, y)];
                 avecount += 1;
@@ -274,11 +269,12 @@ pub fn makevege(
     let aveg = aveg as f64 / avecount as f64;
     let ye2 = Rgba([255, 219, 166, 255]);
     let mut imgye2 = RgbaImage::from_pixel(img_width, img_height, Rgba([255, 255, 255, 0]));
-    for x in 4..(wy as usize - 3) {
-        for y in 4..(hy as usize - 3) {
+    for x in 0..(w_3 - 2) {
+        for y in 0..(h_3 - 2) {
             let mut ghit2 = 0;
             let mut highhit2 = 0;
 
+            // sum in a 2x2 area
             for i in x..x + 2 {
                 for j in y..y + 2 {
                     ghit2 += yhit[(i, j)];
@@ -288,7 +284,7 @@ pub fn makevege(
             if ghit2 as f64 / (highhit2 as f64 + ghit2 as f64 + 0.01) > yellowthreshold {
                 draw_filled_rect_mut(
                     &mut imgye2,
-                    Rect::at(x as i32 * 3 + 2, (hy as i32 - y as i32) * 3 - 3).of_size(3, 3),
+                    Rect::at(x as i32 * 3 + 2, (h_3 as i32 - y as i32) * 3 - 3).of_size(3, 3),
                     ye2,
                 );
             }
@@ -296,8 +292,8 @@ pub fn makevege(
     }
 
     let mut imggr1 = RgbImage::from_pixel(img_width, img_height, Rgb([255, 255, 255]));
-    for x in 2..w as usize {
-        for y in 2..h as usize {
+    for x in 2..w_block {
+        for y in 2..h_block {
             let roof = top[(x, y)]
                 - xyz[(
                     (x as f64 * block / size) as usize,
@@ -346,7 +342,7 @@ pub fn makevege(
                         &mut imggr1,
                         Rect::at(
                             ((x as f64 - 0.5) * block) as i32 - addition,
-                            (((h - y as f64) - 0.5) * block) as i32 - addition,
+                            (((h_block as f64 - y as f64) - 0.5) * block) as i32 - addition,
                         )
                         .of_size(
                             (block as i32 + addition) as u32,
@@ -531,19 +527,19 @@ pub fn makevege(
     let tmpfactor = (600.0 / 254.0 / scalefactor) as f32;
 
     let bf32 = block as f32;
-    let hf32 = h as f32;
-    let ww = w as f32 * bf32;
+    let hf32 = h_block as f32;
+    let ww = w_block as f32 * bf32;
     let hh = hf32 * bf32;
     let mut x = 0.0_f32;
 
     let mut imgug = RgbaImage::from_pixel(
-        (w * block * 600.0 / 254.0 / scalefactor) as u32,
-        (h * block * 600.0 / 254.0 / scalefactor) as u32,
+        (w_block as f64 * block * 600.0 / 254.0 / scalefactor) as u32,
+        (h_block as f64 * block * 600.0 / 254.0 / scalefactor) as u32,
         Rgba([255, 255, 255, 0]),
     );
     let mut img_ug_bit = GrayImage::from_pixel(
-        (w * block * 600.0 / 254.0 / scalefactor) as u32,
-        (h * block * 600.0 / 254.0 / scalefactor) as u32,
+        (w_block as f64 * block * 600.0 / 254.0 / scalefactor) as u32,
+        (h_block as f64 * block * 600.0 / 254.0 / scalefactor) as u32,
         Luma([0x00]),
     );
     loop {

--- a/src/vegetation.rs
+++ b/src/vegetation.rs
@@ -298,22 +298,21 @@ pub fn makevege(
     };
 
     let mut imggr1 = RgbImage::from_pixel(img_width, img_height, Rgb([255, 255, 255]));
-    for x in 2..w_block {
-        for y in 2..h_block {
+    for x in 0..w_block {
+        for y in 0..h_block {
             let roof = top[(x, y)]
                 - xyz[(
                     (x as f64 * block / size) as usize,
                     (y as f64 * block / size) as usize,
                 )];
 
+            // find lowest firsthit in a 5x5 area
             let mut firsthit2 = firsthit[(x, y)];
-            for i in (x - 2)..x + 3_usize {
-                for j in (y - 2)..y + 3_usize {
-                    if i < w_block && j < h_block {
-                        let value = firsthit[(i, j)];
-                        if value < firsthit2 {
-                            firsthit2 = value;
-                        }
+            for i in x.saturating_sub(2)..(x + 3).min(w_block) {
+                for j in y.saturating_sub(2)..(y + 3).min(h_block) {
+                    let value = firsthit[(i, j)];
+                    if value < firsthit2 {
+                        firsthit2 = value;
                     }
                 }
             }


### PR DESCRIPTION
This PR started out by just extracting the core algorithm for generating contours into a separate (testable) inner function.  I added some _very_ basic unit tests also. At the same time I also made the generation iterate over the _entire_ grid instead of some (to me) arbitrary choices (start at 1 in x, start at 2 in y etc...). This makes more sense to me. 

In the heightmap generation there was also a lot of `+1` and `+2` which were a bit confusing. So I decided that instead of adding a few here and there (presumably done to avoid some indexing bounds issues) compute the exact right bounds we need and then just use that. This does mean, however that the output changed a little bit, and that the curves are shifted by a pixel or two. No biggie IMO.

Doing that also uncovered some problematic indexing strategies in vegetation generation which caused panicks. I went ahead and fixed that to use the same correct bounds as the heightmap, and also updated the logic there for drawing on the _entire_ image instead of arbitrarily skipping a few pixels on the sides. This did, however, make the output image in the regression test 10 pixels bigger :smile: which kind of breaks the test. It says it passed, but actually the comparison just failed because the images are not the same size. Using imagemagick, I've been able to compare the outputs "for real" and I will attach an image here based on the latest regression test run. Since I changed some of the bounds, the yellow and green areas have moved around a little bit, which is very clear in this comparison image:

TODO

but for the naked eye the difference is rather negligble IMO. You can download the regression test output to check for yourself.

All-in-all this _does change the output_, but in my opinion it is worth it to just clean up the indexing and make the entire code more coherent. If someone disagrees, we can skip these changes altogether, or delay them for a later stage :rocket: 

(Clippy is failing because we need to pin the rust version, see #)